### PR TITLE
food OpenAPI ETL, elastic search

### DIFF
--- a/Data/postgresql.schema.init.sql
+++ b/Data/postgresql.schema.init.sql
@@ -104,8 +104,10 @@ CREATE TABLE food (
                       food_name VARCHAR(50) NOT NULL,
                       manufacturer VARCHAR(50),
                       unit_kcal DECIMAL(4,1) NOT NULL,
-                      unit_weight BIGINT NOT NULL,
-                      PRIMARY KEY (food_id)
+                      unit_gram BIGINT NOT NULL,
+                      food_size INT,
+                      PRIMARY KEY (food_id),
+                      CONSTRAINT uq_food_name_mfr UNIQUE (food_name, manufacturer) -- 이름+제조사 중복 방지
 );
 
 CREATE TABLE nutrition_category (
@@ -121,7 +123,9 @@ CREATE TABLE nutrition_detail (
                                   nutrition_nm VARCHAR(50) NOT NULL,
                                   amount NUMERIC(4,1) NOT NULL,
                                   unit_weight BIGINT NOT NULL,
-                                  PRIMARY KEY (nutrition_id)
+                                  PRIMARY KEY (nutrition_id),
+                                  FOREIGN KEY (food_id) REFERENCES food(food_id),
+                                  FOREIGN KEY (food_cate_id) REFERENCES nutrition_category(food_cate_id)
 );
 
 CREATE TABLE team (
@@ -330,6 +334,8 @@ CREATE INDEX idx_member_team_ranking ON member_team_ranking (team_id, period_val
 
 CREATE INDEX idx_team_global_ranking ON team_global_ranking (period_value);
 
+CREATE UNIQUE INDEX ux_nd_food_cate_nm ON nutrition_detail (food_id, food_cate_id, nutrition_nm);
+
 COMMENT ON COLUMN member.provider_id IS '소셜에서 들어오는 provider';
 
 COMMENT ON COLUMN member.member_img IS 'AWS S3의 URL그대로 기록하기';
@@ -437,3 +443,11 @@ ALTER TABLE daily_mission_behavior ADD CONSTRAINT FK_behavior_TO_daily_mission_b
 ALTER TABLE member_behavior_log ADD CONSTRAINT FK_member_TO_member_behavior_log FOREIGN KEY (member_id) REFERENCES member (member_id);
 
 ALTER TABLE member_behavior_log ADD CONSTRAINT FK_behavior_TO_member_behavior_log FOREIGN KEY (behavior_id) REFERENCES behavior (behavior_id);
+
+INSERT INTO nutrition_category (food_cate_id, category) VALUES
+                                                            (1, '탄수화물'),
+                                                            (2, '단백질'),
+                                                            (3, '지방'),
+                                                            (4, '무기질'),
+                                                            (5, '기타')
+ON CONFLICT (food_cate_id) DO NOTHING;

--- a/Infra/docker-compose.infra.yml
+++ b/Infra/docker-compose.infra.yml
@@ -8,25 +8,27 @@ services:
       - nyam_server
     restart: unless-stopped
 
-#    nyam-elasticsearch:
-#      image: docker.elastic.co/elasticsearch/elasticsearch:8.12.0
-#      restart: always
-#      container_name: nyam-elasticsearch
-#      environment:
-#        - node.name=es01
-#        - discovery.type=single-node
-#        - xpack.security.enabled=false
-#      ulimits:
-#        memlock:
-#          soft: -1
-#          hard: -1
-#      ports:
-#        - "9200:9200"
-#        - "9300:9300"
-#      volumes:
-#        - ./volumes/esdata:/usr/share/elasticsearch/data
-#      networks:
-#        - nyam_server
+  nyam-elasticsearch:
+    build:
+      context: ./elasticsearch
+    image: nyam-elasticsearch:8.12.0-nori
+    container_name: nyam-elasticsearch
+    restart: always
+    environment:
+      - node.name=es01
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    volumes:
+      - ./volumes/esdata:/usr/share/elasticsearch/data
+    networks:
+      - nyam_server
 
 networks:
   nyam_server:

--- a/Infra/elasticsearch/Dockerfile
+++ b/Infra/elasticsearch/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.12.0
+
+# Nori 플러그인 설치
+RUN elasticsearch-plugin install --batch analysis-nori

--- a/everyday/build.gradle
+++ b/everyday/build.gradle
@@ -59,8 +59,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-
-
+	// elasticsearch
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 }
 
 tasks.named('test') {

--- a/everyday/src/main/java/com/nyam/everyday/etl/api/NutriApiClient.java
+++ b/everyday/src/main/java/com/nyam/everyday/etl/api/NutriApiClient.java
@@ -1,0 +1,108 @@
+package com.nyam.everyday.etl.api;
+
+import com.nyam.everyday.etl.api.dto.NutriApiItem;
+import com.nyam.everyday.etl.api.dto.NutriApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * NutriApiClient
+ *
+ * @author : 장소희
+ * @fileName : NutriApiClient
+ * @since : 25. 8. 12.
+ * 영양성분 OpenAPI 호출 클라이언트.
+ * - Spring 6 RestClient 사용(간결, 테스트 용이)
+ */
+
+
+
+@Slf4j
+@Component
+@EnableConfigurationProperties(NutriApiProperties.class)
+public class NutriApiClient {
+
+    private final RestClient http;
+    private final NutriApiProperties props;
+
+    public NutriApiClient(NutriApiProperties props) {
+        this.props = props;
+
+        // 1) 재인코딩 방지
+        DefaultUriBuilderFactory ubf = new DefaultUriBuilderFactory(props.getBaseUrl());
+        ubf.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
+
+        // 2) 타임아웃 (간단 버전)
+        var rf = new SimpleClientHttpRequestFactory();
+        rf.setConnectTimeout((int) Duration.ofSeconds(5).toMillis());
+        rf.setReadTimeout((int) Duration.ofSeconds(10).toMillis());
+
+        this.http = RestClient.builder()
+                .uriBuilderFactory(ubf)
+                .requestFactory(rf)
+                .build();
+    }
+
+    /** 1페이지 조회 */
+    public List<NutriApiItem> fetchItems(int page, int rows) {
+        int safePage = Math.max(1, page);
+        int safeRows = rows > 0 ? rows : props.getDefaultPageSize();
+
+        MultiValueMap<String, String> q = new LinkedMultiValueMap<>();
+        q.add("serviceKey", props.getServiceKey()); // 이미 인코딩된 키면 그대로!
+        q.add("type", "json");
+        q.add("pageNo", String.valueOf(safePage));
+        q.add("numOfRows", String.valueOf(safeRows));
+
+        try {
+            // 호출 전 URL 미리 로깅
+            String previewUrl = props.getBaseUrl() + "?pageNo=" + safePage + "&numOfRows=" + safeRows + "&type=json&serviceKey=****";
+            log.info("[NutriApi] GET {}", previewUrl);
+
+            NutriApiResponse res = http.get()
+                    .uri(b -> b.queryParams(q).build())
+                    .retrieve()
+                    .body(NutriApiResponse.class);
+
+            if (res == null || res.getResponse() == null ||
+                    res.getResponse().getHeader() == null ||
+                    res.getResponse().getBody() == null) {
+                throw new IllegalStateException("응답 파싱 실패(page=" + safePage + ")");
+            }
+
+            var header = res.getResponse().getHeader();
+            String code = header.getResultCode();
+            String msg  = header.getResultMsg();
+            log.debug("[NutriApi] resultCode={}, resultMsg={}", code, msg);
+
+            if (!"00".equals(code)) {
+                throw new IllegalStateException("OpenAPI 오류: " + code + " / " + msg + " (page=" + safePage + ")");
+            }
+
+            List<NutriApiItem> items = res.getResponse().getBody().getItems();
+            return (items != null) ? items : Collections.emptyList();
+
+        } catch (RestClientResponseException ex) {
+            log.error("[NutriApi] HTTP {} : {}", ex.getRawStatusCode(), cut(ex.getResponseBodyAsString(), 500));
+            throw new IllegalStateException("HTTP 오류 " + ex.getRawStatusCode(), ex);
+        } catch (Exception ex) {
+            log.error("[NutriApi] 호출 실패 page={}, rows={}", safePage, safeRows, ex);
+            throw new IllegalStateException("API 호출 실패(page=" + safePage + ", rows=" + safeRows + ")", ex);
+        }
+    }
+
+    private static String cut(String s, int max) {
+        return (s == null || s.length() <= max) ? s : s.substring(0, max) + "...";
+    }
+}

--- a/everyday/src/main/java/com/nyam/everyday/etl/api/NutriApiProperties.java
+++ b/everyday/src/main/java/com/nyam/everyday/etl/api/NutriApiProperties.java
@@ -1,0 +1,25 @@
+package com.nyam.everyday.etl.api;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * NutriApiProperties
+ *
+ * @author : 장소희
+ * @fileName : NutriApiProperties
+ * @since : 25. 8. 12.
+ *
+ * application.yml 의 openapi.nutri.* 바인딩
+ */
+
+@Setter
+@Getter
+@ConfigurationProperties(prefix = "openapi.nutri")
+public class NutriApiProperties {
+    private String baseUrl;       // 예: http://api.data.go.kr/openapi/tn_pubr_public_nutri_process_info_api
+    private String serviceKey;    // URL-encoded key
+    private int defaultPageSize = 100;
+
+}

--- a/everyday/src/main/java/com/nyam/everyday/etl/api/dto/NutriApiBody.java
+++ b/everyday/src/main/java/com/nyam/everyday/etl/api/dto/NutriApiBody.java
@@ -1,0 +1,26 @@
+package com.nyam.everyday.etl.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+/*
+ * NutriApiBody
+ *
+ * @author : 장소희
+ * @fileName : NutriApiBody
+ * @since : 25. 8. 12.
+ */
+
+/** OpenAPI response.body */
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NutriApiBody {
+    @JsonProperty("items")      private List<NutriApiItem> items;
+    @JsonProperty("totalCount") private String totalCount;
+    @JsonProperty("numOfRows")  private String numOfRows;
+    @JsonProperty("pageNo")     private String pageNo;
+
+}

--- a/everyday/src/main/java/com/nyam/everyday/etl/api/dto/NutriApiHeader.java
+++ b/everyday/src/main/java/com/nyam/everyday/etl/api/dto/NutriApiHeader.java
@@ -1,0 +1,22 @@
+package com.nyam.everyday.etl.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+/**
+ * NutriApiHeader
+ *
+ * @author : 장소희
+ * @fileName : NutriApiHeader
+ * @since : 25. 8. 12.
+ */
+
+/** OpenAPI response.header */
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NutriApiHeader {
+    @JsonProperty("resultCode") private String resultCode;
+    @JsonProperty("resultMsg")  private String resultMsg;
+    @JsonProperty("type")       private String type;
+}

--- a/everyday/src/main/java/com/nyam/everyday/etl/api/dto/NutriApiItem.java
+++ b/everyday/src/main/java/com/nyam/everyday/etl/api/dto/NutriApiItem.java
@@ -1,0 +1,41 @@
+package com.nyam.everyday.etl.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+/**
+ * NutriApiItem
+ *
+ * @author : 장소희
+ * @fileName : NutriApiItem
+ * @since : 25. 8. 12.
+ * OpenAPI "items" 한 건 모델.
+ *  - 숫자도 문자열로 받고, 변환은 서비스/유틸에서 일괄 처리(깨끗한 책임 분리).
+ */
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NutriApiItem {
+
+    @JsonProperty("foodCd") private String foodCd;
+    @JsonProperty("foodNm") private String foodNm;
+    @JsonProperty("mfrNm")  private String mfrNm;
+
+    @JsonProperty("nutConSrtrQua") private String nutConSrtrQua; // "100g", "100ml"
+    @JsonProperty("foodSize")      private String foodSize;      // "1000g", "85ml"
+
+    // 에너지/주요영양소
+    @JsonProperty("enerc") private String enerc;  // kcal
+    @JsonProperty("prot")  private String prot;   // g
+    @JsonProperty("fatce") private String fatce;  // g
+    @JsonProperty("chocdf")private String chocdf; // g
+    @JsonProperty("sugar") private String sugar;  // g
+    @JsonProperty("fibtg") private String fibtg;  // g
+
+    // 미네랄/지방산 등
+    @JsonProperty("nat")   private String nat;    // mg
+    @JsonProperty("chole") private String chole;  // mg
+    @JsonProperty("fasat") private String fasat;  // g
+    @JsonProperty("fatrn") private String fatrn;  // g
+
+}

--- a/everyday/src/main/java/com/nyam/everyday/etl/api/dto/NutriApiResponse.java
+++ b/everyday/src/main/java/com/nyam/everyday/etl/api/dto/NutriApiResponse.java
@@ -1,0 +1,29 @@
+package com.nyam.everyday.etl.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+/**
+ * NutriApiResponse
+ *
+ * @author : 장소희
+ * @fileName : NutriApiResponse
+ * @since : 25. 8. 12.
+ */
+
+/** OpenAPI 최상위 래퍼: { "response": { header, body } } */
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NutriApiResponse {
+
+    @JsonProperty("response")
+    private Response response;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Response {
+        @JsonProperty("header") private NutriApiHeader header;
+        @JsonProperty("body")   private NutriApiBody body;
+
+    }
+}

--- a/everyday/src/main/java/com/nyam/everyday/etl/core/NutriConverters.java
+++ b/everyday/src/main/java/com/nyam/everyday/etl/core/NutriConverters.java
@@ -1,0 +1,83 @@
+package com.nyam.everyday.etl.core;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+/**
+ * NutriConverters
+ *
+ * @author : 장소희
+ * @fileName : NutriConverters
+ * @since : 25. 8. 12.
+ * 파싱/단위변환/스케일링 유틸.
+ * - 정책: 항상 per 100g 저장. nutConSrtrQua가 100ml인 경우도 100g으로 가정(assumed density=1.0).
+ */
+
+public final class NutriConverters {
+    private NutriConverters() {}
+
+    private static final Pattern QTY = Pattern.compile("(\\d+(?:\\.\\d+)?)\\s*(g|ml)?", Pattern.CASE_INSENSITIVE);
+    private static final BigDecimal ONE_HUNDRED = new BigDecimal("100");
+    private static final BigDecimal MAX_4_1 = new BigDecimal("999.9");
+
+    /** 수치 파싱 (null/빈/비수치 → empty) */
+    public static Optional<BigDecimal> parseNumber(String s) {
+        if (s == null) return Optional.empty();
+        String t = s.trim();
+        if (t.isEmpty()) return Optional.empty();
+        try {
+            return Optional.of(new BigDecimal(t));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
+    /** "100g" / "85ml" → (값, 단위). 못 읽으면 empty */
+    public static Optional<Quantity> parseQuantity(String s) {
+        if (s == null) return Optional.empty();
+        Matcher m = QTY.matcher(s.trim());
+        if (!m.matches()) return Optional.empty();
+        BigDecimal v = new BigDecimal(m.group(1));
+        String u = m.group(2);
+        UnitKind kind = ("ml".equalsIgnoreCase(u)) ? UnitKind.ML : UnitKind.G;
+        return Optional.of(new Quantity(v, kind));
+    }
+
+    public enum UnitKind { G, ML }
+
+    /** 수량 + 단위 */
+    public record Quantity(BigDecimal value, UnitKind unit) {}
+
+    /** mg → g */
+    public static BigDecimal mgToG(BigDecimal mg) {
+        return mg.divide(new BigDecimal("1000"), 6, RoundingMode.HALF_UP);
+    }
+
+    /** 반올림(소수 1자리) */
+    public static BigDecimal round1(BigDecimal v) {
+        return v.setScale(1, RoundingMode.HALF_UP);
+    }
+
+    /** NUMERIC(4,1) 범위 클램프 */
+    public static BigDecimal clamp4_1(BigDecimal v) {
+        BigDecimal abs = v.abs();
+        if (abs.compareTo(MAX_4_1) > 0) {
+            return v.signum() >= 0 ? MAX_4_1 : MAX_4_1.negate();
+        }
+        return v;
+    }
+
+    /**
+     * per Xg(or ml) 값을 per 100g로 환산.
+     * - ml은 밀도 1.0 가정으로 Xml == Xg 처리.
+     */
+    public static BigDecimal toPer100g(BigDecimal valuePerX, Quantity base) {
+        if (valuePerX == null || base == null) return BigDecimal.ZERO;
+        BigDecimal grams = base.value(); // ml도 1:1로 간주
+        if (grams.compareTo(BigDecimal.ZERO) <= 0) return BigDecimal.ZERO;
+        BigDecimal factor = ONE_HUNDRED.divide(grams, 6, RoundingMode.HALF_UP);
+        return valuePerX.multiply(factor);
+    }
+}

--- a/everyday/src/main/java/com/nyam/everyday/etl/core/NutrientType.java
+++ b/everyday/src/main/java/com/nyam/everyday/etl/core/NutrientType.java
@@ -1,0 +1,49 @@
+package com.nyam.everyday.etl.core;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * NutrientType
+ *
+ * @author : 장소희
+ * @fileName : NutrientType
+ * @since : 25. 8. 12.
+ * 선택 영양소 매핑(카테고리/라벨/원본 API 필드).
+ *  - 카테고리 ID는 시드 기준: 탄수화물=1, 단백질=2, 지방=3, 무기질=4
+ */
+
+public enum NutrientType {
+    PROTEIN("prot",  "단백질",    2, Unit.G),
+    FAT("fatce",     "지방",      3, Unit.G),
+    CARB("chocdf",   "탄수화물",  1, Unit.G),
+    SUGAR("sugar",   "당류",      1, Unit.G),
+    FIBER("fibtg",   "식이섬유",  1, Unit.G),
+    SODIUM("nat",    "나트륨",    4, Unit.MG),
+    CHOLE("chole",   "콜레스테롤",3, Unit.MG),
+    FASAT("fasat",   "포화지방산",3, Unit.G),
+    FATRN("fatrn",   "트랜스지방산",3, Unit.G);
+
+    public enum Unit { G, MG }
+
+    private final String apiField;
+    private final String label;
+    private final int categoryId;
+    private final Unit unit;
+
+    NutrientType(String apiField, String label, int categoryId, Unit unit) {
+        this.apiField = apiField;
+        this.label = label;
+        this.categoryId = categoryId;
+        this.unit = unit;
+    }
+
+    public String apiField() { return apiField; }
+    public String label() { return label; }
+    public int categoryId() { return categoryId; }
+    public Unit unit() { return unit; }
+
+    public static List<NutrientType> selected() {
+        return Arrays.asList(values());
+    }
+}

--- a/everyday/src/main/java/com/nyam/everyday/etl/service/FoodEtlService.java
+++ b/everyday/src/main/java/com/nyam/everyday/etl/service/FoodEtlService.java
@@ -1,0 +1,227 @@
+package com.nyam.everyday.etl.service;
+
+import com.nyam.everyday.etl.api.NutriApiClient;
+import com.nyam.everyday.etl.api.dto.NutriApiItem;
+import com.nyam.everyday.etl.core.NutrientType;
+import com.nyam.everyday.etl.core.NutriConverters;
+import com.nyam.everyday.etl.core.NutriConverters.Quantity;
+import com.nyam.everyday.etl.core.NutriConverters.UnitKind;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.nyam.everyday.module.food.entity.Food;
+import com.nyam.everyday.module.food.entity.NutritionDetail;
+import com.nyam.everyday.module.food.repository.FoodRepository;
+import com.nyam.everyday.module.food.repository.NutritionDetailRepository;
+import com.nyam.everyday.search.service.FoodSearchIndexer;
+import com.nyam.everyday.search.mapper.FoodSearchMapper;
+
+
+/**
+ * FoodEtlService
+ *
+ * @author : 장소희
+ * @fileName : FoodEtlService
+ * @since : 25. 8. 12.
+ *
+ * OpenAPI -> 표준화 -> 업서트 -> 리포트
+ * - 항상 per 100g 저장, ml도 1:1 가정(라벨은 원본 보존하지 않아도 되면 스킵)
+ */
+
+@Service
+public class FoodEtlService {
+
+    private final NutriApiClient api;
+    private final FoodRepository foodRepo;
+    private final NutritionDetailRepository ndRepo;
+    private final FoodSearchIndexer foodIndexer;
+    private final FoodSearchMapper foodMapper;
+
+    public FoodEtlService(NutriApiClient api, FoodRepository foodRepo, NutritionDetailRepository ndRepo, FoodSearchIndexer foodIndexer, FoodSearchMapper foodMapper) {
+        this.api = api;
+        this.foodRepo = foodRepo;
+        this.ndRepo = ndRepo;
+        this.foodIndexer = foodIndexer;
+        this.foodMapper  = foodMapper;
+    }
+
+    @Transactional
+    public EtlReport run(int page, int rows, boolean dryRun) {
+        List<NutriApiItem> items = api.fetchItems(page, rows);
+
+        EtlReport r = new EtlReport(page, rows, items.size());
+        for (NutriApiItem it : items) {
+            try {
+                processOne(it, dryRun, r);
+            } catch (Exception e) {
+                r.errors++;
+                r.errorSamples.add(shortItem(it) + " :: " + e.getMessage());
+            }
+        }
+        // ES 벌크 전송 (dryRun이면 생략)
+        if (!dryRun) {
+            try {
+                foodIndexer.flush();
+            } catch (Exception e) {
+                r.errors++;
+                r.errorSamples.add("[ES] flush failed: " + e.getMessage());
+            }
+        }
+        return r;
+    }
+
+    private void processOne(NutriApiItem it, boolean dryRun, EtlReport r) {
+        String name = safeTrim(it.getFoodNm());
+        String mfr  = emptyToNull(safeTrim(it.getMfrNm()));
+        if (name == null) { r.skippedParse++; return; }
+
+        // 기준량: "100g" / "100ml" -> Quantity (기본 100g)
+        Quantity base = NutriConverters.parseQuantity(it.getNutConSrtrQua())
+                .orElse(new Quantity(new BigDecimal("100"), UnitKind.G));
+
+        // 1) food upsert
+        Food food = upsertFood(it, name, mfr, base, dryRun, r);
+
+        // ES 버퍼에 추가 (DB upsert가 성공했을 때만)
+        if (!dryRun) {
+            try {
+                foodIndexer.add(foodMapper.from(food));
+            } catch (Exception e) {
+                // 인덱싱 실패는 리포트에만 기록하고 계속 진행
+                r.errors++;
+                r.errorSamples.add("[ES] index add failed for foodId=" + food.getFoodId() + ": " + e.getMessage());
+            }
+        }
+
+        // 2) nutrition_detail upsert
+        for (NutrientType nt : NutrientType.selected()) {
+            BigDecimal raw = NutriConverters.parseNumber(getFieldByName(it, nt.apiField()))
+                    .orElse(BigDecimal.ZERO);
+
+            if (nt.unit() == NutrientType.Unit.MG) {
+                raw = NutriConverters.mgToG(raw); // mg -> g
+            }
+
+            BigDecimal per100g = NutriConverters.toPer100g(raw, base);
+            per100g = NutriConverters.round1(NutriConverters.clamp4_1(per100g));
+
+            upsertDetail(food.getFoodId(), nt.categoryId(), nt.label(), per100g, dryRun, r);
+        }
+    }
+
+    private Food upsertFood(NutriApiItem it, String name, String mfr,
+                            Quantity base, boolean dryRun, EtlReport r) {
+
+        // kcal per 100g 환산
+        BigDecimal kcal = NutriConverters.parseNumber(it.getEnerc()).orElse(BigDecimal.ZERO);
+        BigDecimal kcalPer100g = NutriConverters.round1(
+                NutriConverters.toPer100g(kcal, base)
+        );
+
+        // 항상 100g 기준 저장
+        Long unitGram = 100L;
+
+        // foodSize: g만 허용(ml → g 환산 정책 미적용)
+        Integer foodSize = NutriConverters.parseQuantity(it.getFoodSize())
+                .filter(q -> q.unit() == UnitKind.G)
+                .map(q -> q.value().intValue())
+                .orElse(null);
+
+        // (food_name, manufacturer)로 조회 (manufacturer NULL 가능 → 빈문자 대체)
+        Optional<Food> found =
+                foodRepo.findByFoodNameAndManufacturerNullSafe(name, nvl(mfr, ""));
+
+        if (found.isEmpty()) {
+            Food f = Food.builder()
+                    .foodName(name)
+                    .manufacturer(mfr)
+                    .unitKcal(kcalPer100g)
+                    .unitGram(unitGram)   // Long 필드
+                    .foodSize(foodSize)     // Integer 필드
+                    .build();
+
+            if (!dryRun) foodRepo.save(f);
+            r.inserted++;
+            return f;
+        } else {
+            Food existed = found.get();
+            existed.setFoodName(name);          // 혹시 원본명이 바뀐 경우 동기화(선택)
+            existed.setManufacturer(mfr);       // 제조사도 동기화(선택)
+            existed.setUnitKcal(kcalPer100g);
+            existed.setUnitGram(unitGram);
+            existed.setFoodSize(foodSize);
+            if (!dryRun) foodRepo.save(existed);
+            r.updated++;
+            return existed;
+        }
+    }
+
+    private void upsertDetail(Long foodId, int cateId, String nm, BigDecimal amount,
+                              boolean dryRun, EtlReport r) {
+
+        Optional<NutritionDetail> found =
+                ndRepo.findByFoodIdAndFoodCateIdAndNutritionNm(foodId, (long) cateId, nm);
+
+        if (found.isEmpty()) {
+            NutritionDetail nd = NutritionDetail.builder()
+                    .foodId(foodId)
+                    .foodCateId((long) cateId)
+                    .nutritionNm(nm)
+                    .amount(amount)
+                    .unitWeight(100L) // NutritionDetail이 BIGINT라면 Long 사용
+                    .build();
+
+            if (!dryRun) ndRepo.save(nd);
+            r.inserted++;
+        } else {
+            NutritionDetail existed = found.get();
+            existed.setAmount(amount);
+            existed.setUnitWeight(100L);
+            if (!dryRun) ndRepo.save(existed);
+            r.updated++;
+        }
+    }
+
+    private static String getFieldByName(NutriApiItem it, String apiField) {
+        return switch (apiField) {
+            case "prot"  -> it.getProt();
+            case "fatce" -> it.getFatce();
+            case "chocdf"-> it.getChocdf();
+            case "sugar" -> it.getSugar();
+            case "fibtg" -> it.getFibtg();
+            case "nat"   -> it.getNat();
+            case "chole" -> it.getChole();
+            case "fasat" -> it.getFasat();
+            case "fatrn" -> it.getFatrn();
+            default -> null;
+        };
+    }
+
+    private static String safeTrim(String s) { return (s == null) ? null : s.trim(); }
+    private static String emptyToNull(String s) { return (s == null || s.isBlank()) ? null : s; }
+    private static String nvl(String s, String def) { return (s == null) ? def : s; }
+
+    /** 간단 리포트 */
+    public static class EtlReport {
+        public final int page;
+        public final int rows;
+        public final int received;
+        public int inserted;
+        public int updated;
+        public int skippedParse;
+        public int errors;
+        public final List<String> errorSamples = new ArrayList<>();
+        public EtlReport(int page, int rows, int received) {
+            this.page = page; this.rows = rows; this.received = received;
+        }
+    }
+
+    private static String shortItem(NutriApiItem it) {
+        return "[" + it.getFoodCd() + "] " + it.getFoodNm();
+    }
+}

--- a/everyday/src/main/java/com/nyam/everyday/etl/web/FoodEtlAdminController.java
+++ b/everyday/src/main/java/com/nyam/everyday/etl/web/FoodEtlAdminController.java
@@ -1,0 +1,44 @@
+package com.nyam.everyday.etl.web;
+
+
+import com.nyam.everyday.etl.service.FoodEtlService;
+import com.nyam.everyday.etl.service.FoodEtlService.EtlReport;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * FoodEtlAdminController
+ *
+ * @author : 장소희
+ * @fileName : FoodEtlAdminController
+ * @since : 25. 8. 12.
+ *
+ * 관리자 전용 ETL 트리거 엔드포인트.
+ * - 권한: ROLE_ADMIN
+ * - 예: POST /api/admin/etl/foods/run?page=1&rows=100&dryRun=true
+ */
+
+@RestController
+@RequestMapping("/api/admin/etl/foods")
+public class FoodEtlAdminController {
+
+    private final FoodEtlService service;
+
+    public FoodEtlAdminController(FoodEtlService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "Food ETL 실행", description = "OpenAPI에서 식품/영양소를 조회하여 DB에 업서트합니다.")
+    @PostMapping("/run")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<EtlReport> run(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "100") int rows,
+            @RequestParam(defaultValue = "false") boolean dryRun
+    ) {
+        EtlReport report = service.run(page, rows, dryRun);
+        return ResponseEntity.ok(report);
+    }
+}

--- a/everyday/src/main/java/com/nyam/everyday/module/food/entity/Food.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/food/entity/Food.java
@@ -42,5 +42,9 @@ public class Food {
 
     @Comment("단위 무게 (g)")
     @Column(nullable = false)
-    private Long unitWeight;
+    private Long unitGram;
+
+    @Comment("식품 크기 (g) — API 제공값, null 가능")
+    @Column
+    private Integer foodSize;
 }

--- a/everyday/src/main/java/com/nyam/everyday/module/food/repository/FoodRepository.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/food/repository/FoodRepository.java
@@ -2,7 +2,11 @@ package com.nyam.everyday.module.food.repository;
 
 import com.nyam.everyday.module.food.entity.Food;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 /**
  * Food Repository
@@ -15,4 +19,17 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface FoodRepository extends JpaRepository<Food, Long> {
 
+    @Query("""
+        select f
+          from Food f
+         where lower(trim(f.foodName)) = lower(trim(:foodName))
+           and (
+                (f.manufacturer is null and :manufacturer = '')
+                or lower(trim(f.manufacturer)) = lower(trim(:manufacturer))
+           )
+    """)
+    Optional<Food> findByFoodNameAndManufacturerNullSafe(
+            @Param("foodName") String foodName,
+            @Param("manufacturer") String manufacturer
+    );
 }

--- a/everyday/src/main/java/com/nyam/everyday/module/food/repository/NutritionDetailRepository.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/food/repository/NutritionDetailRepository.java
@@ -4,6 +4,8 @@ import com.nyam.everyday.module.food.entity.NutritionDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 /**
  * NutritionDetail Repository
  *
@@ -14,5 +16,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NutritionDetailRepository extends JpaRepository<NutritionDetail, Long> {
-
+    Optional<NutritionDetail> findByFoodIdAndFoodCateIdAndNutritionNm(Long foodId, Long foodCateId, String nutritionNm);
 }

--- a/everyday/src/main/java/com/nyam/everyday/oauth2/OAuth2LoginSuccessHandler.java
+++ b/everyday/src/main/java/com/nyam/everyday/oauth2/OAuth2LoginSuccessHandler.java
@@ -1,6 +1,5 @@
 package com.nyam.everyday.oauth2;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -56,7 +55,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     response.addCookie(refreshTokenCookie);
 
 
-    // response.sendRedirect("/main.html?" + "&memberId=" + memberId);
-    response.sendRedirect("http://localhost:5173/");//리액트
+    response.sendRedirect("/main.html?" + "&memberId=" + memberId);
   }
 }

--- a/everyday/src/main/java/com/nyam/everyday/search/bootstrap/FoodIndexBootstrap.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/bootstrap/FoodIndexBootstrap.java
@@ -1,0 +1,52 @@
+package com.nyam.everyday.search.bootstrap;
+
+import com.nyam.everyday.search.document.FoodDocument;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.stereotype.Component;
+
+/**
+ * FoodIndexBootstrap
+ *
+ * @author : 장소희
+ * @fileName : FoodIndexBootstrap
+ * @since : 25. 8. 13.
+ *
+ * 앱 시작 시 ES 인덱스 자동 생성/검증
+ *  - FoodDocument에 선언한 @Setting/@Mapping을 읽어서 생성
+ *  - 이미 있으면 건드리지 않음(매핑/분석기 변경은 재색인 전략 필요)
+ *
+ */
+
+@Slf4j
+@Component
+@Profile({"local", "dev"}) // 운영은 보통 수동/배치로 관리. 원하면 제거해도 됨.
+@RequiredArgsConstructor
+public class FoodIndexBootstrap implements ApplicationRunner {
+
+    private final ElasticsearchOperations operations;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        IndexOperations indexOps = operations.indexOps(FoodDocument.class);
+
+        if (!indexOps.exists()) {
+
+            boolean created = indexOps.create();
+            if (created) {
+                indexOps.putMapping(indexOps.createMapping());
+                log.info("[ES] index 'food' created with settings/mappings.");
+            } else {
+                log.warn("[ES] index 'food' create() returned false.");
+            }
+        } else {
+            log.info("[ES] index 'food' already exists. (no changes applied)");
+
+        }
+    }
+}

--- a/everyday/src/main/java/com/nyam/everyday/search/config/ElasticsearchConfig.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/config/ElasticsearchConfig.java
@@ -1,0 +1,21 @@
+package com.nyam.everyday.search.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+/**
+ * ElasticsearchConfig
+ *
+ * @author : 장소희
+ * @fileName : ElasticsearchConfig
+ * @since : 25. 8. 13.
+ *
+ * - spring.elasticsearch.* 설정은 application-*.yml 에서 자동 바인딩되고,
+ *   여기서는 ES Repository 스캔만 활성화합니다.
+ *
+ */
+
+@Configuration
+@EnableElasticsearchRepositories(basePackages = "com.nyam.everyday.search.repository")
+public class ElasticsearchConfig {
+}

--- a/everyday/src/main/java/com/nyam/everyday/search/document/FoodDocument.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/document/FoodDocument.java
@@ -1,0 +1,59 @@
+package com.nyam.everyday.search.document;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.*;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+/**
+ * FoodDocument
+ *
+ * @author : 장소희
+ * @fileName : FoodDocument
+ * @since : 25. 8. 13.
+ *
+ * Elasticsearch에 저장되는 Food 문서 모델
+ * - indexName = "food"  (우리가 만든 인덱스와 동일)
+ * - 검색: foodName(Text + nori), 정합/필터: manufacturer(Keyword)
+ * - 표시: unitKcal, unitGram
+ *
+ */
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document(indexName = "food")
+public class FoodDocument {
+
+    @Id
+    private String id;               // ES 문서 ID (RDB PK를 문자열로 써도 되고, ES가 생성해도 됨)
+
+    /** 음식 이름: 한국어 형태소 분석 + 정확일치 서브필드(keyword) */
+    @MultiField(
+            mainField = @Field(type = FieldType.Text,
+                    analyzer = "korean_search",
+                    searchAnalyzer = "korean_search"),
+            otherFields = {
+                    @InnerField(suffix = "keyword", type = FieldType.Keyword)
+            }
+    )
+    private String foodName;
+
+    /** 제조사: 필터/정확일치 중심이면 Keyword */
+    @Field(type = FieldType.Keyword)
+    private String manufacturer;
+
+    /** 100g 기준 열량 (표시/정렬 등에 사용) */
+    // 매핑을 scaled_float로 만들었더라도 number 전송은 가능하므로 Double로 둬도 OK
+    @Field(type = FieldType.Double)
+    private Double unitKcal;
+
+    /** 기준 g (항상 100 고정으로 넣을 예정) */
+    @Field(type = FieldType.Long)
+    private Long unitGram;
+
+    @Field(type = FieldType.Integer)
+    private Integer foodSize;
+}

--- a/everyday/src/main/java/com/nyam/everyday/search/mapper/FoodSearchMapper.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/mapper/FoodSearchMapper.java
@@ -1,0 +1,25 @@
+package com.nyam.everyday.search.mapper;
+
+import com.nyam.everyday.module.food.entity.Food;
+import com.nyam.everyday.search.document.FoodDocument;
+import org.mapstruct.*;
+
+/**
+ * FoodSearchMapper
+ *
+ * @author : 장소희
+ * @fileName : FoodSearchMapper
+ * @since : 25. 8. 13.
+ */
+
+@Mapper(componentModel = "spring")
+public interface FoodSearchMapper {
+
+    @Mapping(target = "id",        expression = "java(food.getFoodId() == null ? null : String.valueOf(food.getFoodId()))")
+    @Mapping(target = "foodName",  source = "foodName")
+    @Mapping(target = "manufacturer", source = "manufacturer")
+    @Mapping(target = "unitKcal",  expression = "java(food.getUnitKcal() == null ? null : food.getUnitKcal().doubleValue())")
+    @Mapping(target = "unitGram", expression = "java(food.getUnitGram() == null ? null : Long.valueOf(food.getUnitGram()))")
+    @Mapping(target = "foodSize",  source = "foodSize")
+    FoodDocument from(Food food);
+}

--- a/everyday/src/main/java/com/nyam/everyday/search/repository/FoodSearchRepository.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/repository/FoodSearchRepository.java
@@ -1,0 +1,16 @@
+package com.nyam.everyday.search.repository;
+
+import com.nyam.everyday.search.document.FoodDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+/**
+ * FoodSearchRepository
+ *
+ * @author : 장소희
+ * @fileName : FoodSearchRepository
+ * @since : 25. 8. 13.
+ */
+
+public interface FoodSearchRepository extends ElasticsearchRepository<FoodDocument, String> {
+
+}

--- a/everyday/src/main/java/com/nyam/everyday/search/service/FoodSearchIndexer.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/service/FoodSearchIndexer.java
@@ -1,0 +1,43 @@
+package com.nyam.everyday.search.service;
+
+import com.nyam.everyday.search.document.FoodDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * FoodSearchIndexer
+ *
+ * @author : 장소희
+ * @fileName : FoodSearchIndexer
+ * @since : 25. 8. 13.
+ */
+
+@Service
+@RequiredArgsConstructor
+public class FoodSearchIndexer {
+
+    private final ElasticsearchOperations operations;
+
+    private static final int BULK_THRESHOLD = 500;
+    private final List<FoodDocument> buffer = new ArrayList<>();
+
+    /** ETL 동안 계속 호출: 메모리 버퍼에 쌓음, 임계치 넘으면 즉시 flush */
+    public synchronized void add(FoodDocument doc) {
+        if (doc == null) return;
+        buffer.add(doc);
+        if (buffer.size() >= BULK_THRESHOLD) {
+            flush();
+        }
+    }
+
+    /** 루프 끝에서 한 번 호출: 남은 것 모두 저장 */
+    public synchronized void flush() {
+        if (buffer.isEmpty()) return;
+        operations.save(buffer);        // @Document의 indexName("food") 기준으로 벌크 저장
+        buffer.clear();
+    }
+}

--- a/everyday/src/main/resources/application-local.yml
+++ b/everyday/src/main/resources/application-local.yml
@@ -100,3 +100,9 @@ spring:
             user-info-uri: "https://kapi.kakao.com/v2/user/me"
             user-name-attribute: id
 
+
+openapi:
+  nutri:
+    base-url: http://api.data.go.kr/openapi/tn_pubr_public_nutri_process_info_api
+    service-key: ${NUTRI_API_KEY}   # 환경변수에서 주입
+    default-page-size: 100

--- a/everyday/src/main/resources/elasticsearch/food-mappings.json
+++ b/everyday/src/main/resources/elasticsearch/food-mappings.json
@@ -1,0 +1,36 @@
+{
+  "mappings": {
+    "properties": {
+      "foodName": {
+        "type": "text",
+        "analyzer": "korean_search",
+        "search_analyzer": "korean_search",
+        "fields": {
+          "keyword": { "type": "keyword", "ignore_above": 256 },
+          "autocomplete": {
+            "type": "text",
+            "analyzer": "korean_autocomplete",
+            "search_analyzer": "korean_search"
+          }
+        }
+      },
+      "manufacturer": {
+        "type": "keyword",
+        "normalizer": "lowercase"
+      },
+      "unitKcal":   { "type": "scaled_float", "scaling_factor": 10, "index": false },
+      "unitGram":   { "type": "integer",      "index": false },
+      "foodSize":   { "type": "integer",      "index": false }
+    }
+  },
+  "settings": {
+    "analysis": {
+      "normalizer": {
+        "lowercase": {
+          "type": "custom",
+          "filter": ["lowercase"]
+        }
+      }
+    }
+  }
+}

--- a/everyday/src/main/resources/elasticsearch/food-settings.json
+++ b/everyday/src/main/resources/elasticsearch/food-settings.json
@@ -1,0 +1,35 @@
+{
+  "settings": {
+    "analysis": {
+      "filter": {
+        "nori_posfilter": {
+          "type": "nori_part_of_speech",
+          "stoptags": ["E", "IC", "J", "MAG", "MAJ", "MM", "SP", "SSC", "SSO", "SC", "SE", "XPN", "XSA", "XSN", "XSV", "UNA", "NA", "VSV"]
+        },
+        "my_shingle": {
+          "type": "shingle",
+          "min_shingle_size": 2,
+          "max_shingle_size": 2
+        }
+      },
+      "analyzer": {
+        "korean_index": {
+          "type": "custom",
+          "tokenizer": "nori_tokenizer",
+          "filter": ["lowercase", "nori_readingform", "nori_posfilter"]
+        },
+        "korean_search": {
+          "type": "custom",
+          "tokenizer": "nori_tokenizer",
+          "filter": ["lowercase", "nori_readingform", "nori_posfilter", "my_shingle"]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "name": { "type": "text", "analyzer": "korean_index", "search_analyzer": "korean_search" },
+      "desc": { "type": "text", "analyzer": "korean_index", "search_analyzer": "korean_search" }
+    }
+  }
+}


### PR DESCRIPTION
- OpenAPI로부터 food 데이터 수집 및 변환 로직 구현 (ETL)
- PostgreSQL 저장 후 Elasticsearch 색인 처리
- Elasticsearch FoodDocument, 매핑 설정(korean_search analyzer, keyword 필드)
- FoodSearchMapper, Repository, Service 계층 구현
- docker-compose.infra에 Elasticsearch 서비스 추가
- Nori 플러그인 자동 설치 Dockerfile

## 💭 작업 브랜치
feat/etl-food-from-openapi

## 🍀 기능 설명
- OpenAPI로부터 food 데이터 수집 및 변환 로직 구현 (ETL)
- PostgreSQL 저장 후 Elasticsearch 색인 처리
- Elasticsearch FoodDocument, 매핑 설정(korean_search analyzer, keyword 필드)
- FoodSearchMapper, Repository, Service 계층 구현
- docker-compose.infra에 Elasticsearch 서비스 추가
- Nori 플러그인 자동 설치 Dockerfile

## 관련된 Issue
close #61 
