### PR TITLE
feat: elastic search food 적용 #73

### DIFF
--- a/everyday/src/main/java/com/nyam/everyday/etl/api/NutriApiClient.java
+++ b/everyday/src/main/java/com/nyam/everyday/etl/api/NutriApiClient.java
@@ -1,6 +1,6 @@
 package com.nyam.everyday.etl.api;
 
-import com.nyam.everyday.etl.api.dto.NutriApiItem;
+import com.nyam.everyday.etl.api.dto.NutriApiBody;
 import com.nyam.everyday.etl.api.dto.NutriApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -10,11 +10,12 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * NutriApiClient
@@ -25,9 +26,6 @@ import java.util.List;
  * 영양성분 OpenAPI 호출 클라이언트.
  * - Spring 6 RestClient 사용(간결, 테스트 용이)
  */
-
-
-
 @Slf4j
 @Component
 @EnableConfigurationProperties(NutriApiProperties.class)
@@ -36,6 +34,10 @@ public class NutriApiClient {
     private final RestClient http;
     private final NutriApiProperties props;
 
+    // 재시도 기본값
+    private static final int MAX_RETRY = 3;       // 3회
+    private static final long BACKOFF_MS = 1000L; // 1s -> 2s -> 4s
+
     public NutriApiClient(NutriApiProperties props) {
         this.props = props;
 
@@ -43,10 +45,12 @@ public class NutriApiClient {
         DefaultUriBuilderFactory ubf = new DefaultUriBuilderFactory(props.getBaseUrl());
         ubf.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
 
-        // 2) 타임아웃 (간단 버전)
+        // 2) 타임아웃 (프로퍼티 기반)
         var rf = new SimpleClientHttpRequestFactory();
-        rf.setConnectTimeout((int) Duration.ofSeconds(5).toMillis());
-        rf.setReadTimeout((int) Duration.ofSeconds(10).toMillis());
+        int connectMs = (int) props.getConnectTimeout().toMillis();
+        int readMs    = (int) props.getReadTimeout().toMillis();
+        rf.setConnectTimeout(connectMs);
+        rf.setReadTimeout(readMs);
 
         this.http = RestClient.builder()
                 .uriBuilderFactory(ubf)
@@ -54,20 +58,25 @@ public class NutriApiClient {
                 .build();
     }
 
-    /** 1페이지 조회 */
-    public List<NutriApiItem> fetchItems(int page, int rows) {
+    /** 1페이지 조회 (재시도 포함) */
+    public NutriApiBody fetchItems(int page, int rows) {
         int safePage = Math.max(1, page);
         int safeRows = rows > 0 ? rows : props.getDefaultPageSize();
 
         MultiValueMap<String, String> q = new LinkedMultiValueMap<>();
-        q.add("serviceKey", props.getServiceKey()); // 이미 인코딩된 키면 그대로!
+        q.add("serviceKey", props.getServiceKey()); // 이미 인코딩된 키면 그대로
         q.add("type", "json");
         q.add("pageNo", String.valueOf(safePage));
         q.add("numOfRows", String.valueOf(safeRows));
 
-        try {
-            // 호출 전 URL 미리 로깅
-            String previewUrl = props.getBaseUrl() + "?pageNo=" + safePage + "&numOfRows=" + safeRows + "&type=json&serviceKey=****";
+        String previewUrl = props.getBaseUrl()
+                + "?pageNo=" + safePage
+                + "&numOfRows=" + safeRows
+                + "&type=json&serviceKey=****";
+
+        // 재시도 래퍼
+        return withRetry(() -> {
+            long t0 = System.currentTimeMillis();
             log.info("[NutriApi] GET {}", previewUrl);
 
             NutriApiResponse res = http.get()
@@ -75,31 +84,62 @@ public class NutriApiClient {
                     .retrieve()
                     .body(NutriApiResponse.class);
 
-            if (res == null || res.getResponse() == null ||
-                    res.getResponse().getHeader() == null ||
-                    res.getResponse().getBody() == null) {
+            if (res == null || res.getResponse() == null
+                    || res.getResponse().getHeader() == null
+                    || res.getResponse().getBody() == null) {
                 throw new IllegalStateException("응답 파싱 실패(page=" + safePage + ")");
             }
 
             var header = res.getResponse().getHeader();
             String code = header.getResultCode();
             String msg  = header.getResultMsg();
-            log.debug("[NutriApi] resultCode={}, resultMsg={}", code, msg);
-
             if (!"00".equals(code)) {
-                throw new IllegalStateException("OpenAPI 오류: " + code + " / " + msg + " (page=" + safePage + ")");
+                throw new IllegalStateException("OpenAPI 오류: " + code + " / " + msg
+                        + " (page=" + safePage + ")");
             }
 
-            List<NutriApiItem> items = res.getResponse().getBody().getItems();
-            return (items != null) ? items : Collections.emptyList();
+            var body = res.getResponse().getBody();
+            if (body.getItems() == null) {
+                body.setItems(Collections.emptyList());
+            }
 
-        } catch (RestClientResponseException ex) {
-            log.error("[NutriApi] HTTP {} : {}", ex.getRawStatusCode(), cut(ex.getResponseBodyAsString(), 500));
-            throw new IllegalStateException("HTTP 오류 " + ex.getRawStatusCode(), ex);
-        } catch (Exception ex) {
-            log.error("[NutriApi] 호출 실패 page={}, rows={}", safePage, safeRows, ex);
-            throw new IllegalStateException("API 호출 실패(page=" + safePage + ", rows=" + safeRows + ")", ex);
+            log.info("[NutriApi] OK page={}, rows={} -> items={}, {}ms",
+                    safePage, safeRows, body.getItems().size(), System.currentTimeMillis() - t0);
+
+            return body;
+        }, "page=" + safePage + ", rows=" + safeRows);
+    }
+
+    /** 타임아웃/5xx에서 재시도(지수 백오프) */
+    private <T> T withRetry(Supplier<T> call, String tag) {
+        long wait = BACKOFF_MS;
+        for (int attempt = 1; attempt <= MAX_RETRY; attempt++) {
+            try {
+                return call.get();
+            } catch (RestClientResponseException ex) {
+                // 5xx만 재시도, 4xx는 즉시 실패
+                int status = ex.getRawStatusCode();
+                if (status >= 500 && attempt < MAX_RETRY) {
+                    log.warn("[NutriApi][retry {}/{}] {} HTTP {}", attempt, MAX_RETRY, tag, status);
+                } else {
+                    log.error("[NutriApi] {} HTTP {} : {}", tag, status, cut(ex.getResponseBodyAsString(), 500));
+                    throw new IllegalStateException("HTTP 오류 " + status, ex);
+                }
+            } catch (ResourceAccessException ex) {
+                // 타임아웃/연결 문제 재시도
+                if (attempt < MAX_RETRY) {
+                    log.warn("[NutriApi][retry {}/{}] {} : {}", attempt, MAX_RETRY, tag, ex.getMessage());
+                } else {
+                    log.error("[NutriApi] {} : {}", tag, ex.getMessage());
+                    throw new IllegalStateException("API 호출 실패(" + tag + ")", ex);
+                }
+            }
+
+            // 백오프 후 재시도
+            try { Thread.sleep(wait); } catch (InterruptedException ignored) {}
+            wait *= 2; // 1s -> 2s -> 4s
         }
+        throw new IllegalStateException("unreachable");
     }
 
     private static String cut(String s, int max) {

--- a/everyday/src/main/java/com/nyam/everyday/etl/api/NutriApiProperties.java
+++ b/everyday/src/main/java/com/nyam/everyday/etl/api/NutriApiProperties.java
@@ -3,7 +3,7 @@ package com.nyam.everyday.etl.api;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-
+import java.time.Duration;
 /**
  * NutriApiProperties
  *
@@ -21,5 +21,8 @@ public class NutriApiProperties {
     private String baseUrl;       // 예: http://api.data.go.kr/openapi/tn_pubr_public_nutri_process_info_api
     private String serviceKey;    // URL-encoded key
     private int defaultPageSize = 100;
-
+    /** 연결 타임아웃 (기본 10초) */
+    private Duration connectTimeout = Duration.ofSeconds(10);
+    /** 읽기 타임아웃 (기본 60초) */
+    private Duration readTimeout = Duration.ofSeconds(60);
 }

--- a/everyday/src/main/java/com/nyam/everyday/etl/api/dto/NutriApiBody.java
+++ b/everyday/src/main/java/com/nyam/everyday/etl/api/dto/NutriApiBody.java
@@ -3,6 +3,7 @@ package com.nyam.everyday.etl.api.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
@@ -16,6 +17,7 @@ import java.util.List;
 
 /** OpenAPI response.body */
 @Getter
+@Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class NutriApiBody {
     @JsonProperty("items")      private List<NutriApiItem> items;

--- a/everyday/src/main/java/com/nyam/everyday/etl/service/FoodEtlService.java
+++ b/everyday/src/main/java/com/nyam/everyday/etl/service/FoodEtlService.java
@@ -1,138 +1,184 @@
 package com.nyam.everyday.etl.service;
 
 import com.nyam.everyday.etl.api.NutriApiClient;
+import com.nyam.everyday.etl.api.dto.NutriApiBody;
 import com.nyam.everyday.etl.api.dto.NutriApiItem;
-import com.nyam.everyday.etl.core.NutrientType;
 import com.nyam.everyday.etl.core.NutriConverters;
 import com.nyam.everyday.etl.core.NutriConverters.Quantity;
 import com.nyam.everyday.etl.core.NutriConverters.UnitKind;
+import com.nyam.everyday.etl.core.NutrientType;
+import com.nyam.everyday.module.food.entity.Food;
+import com.nyam.everyday.module.food.entity.NutritionDetail;
+import com.nyam.everyday.module.food.repository.FoodRepository;
+import com.nyam.everyday.module.food.repository.NutritionDetailRepository;
+import com.nyam.everyday.search.food.mapper.FoodSearchMapper;
+import com.nyam.everyday.search.food.service.FoodSearchIndexer;
 import jakarta.transaction.Transactional;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import com.nyam.everyday.module.food.entity.Food;
-import com.nyam.everyday.module.food.entity.NutritionDetail;
-import com.nyam.everyday.module.food.repository.FoodRepository;
-import com.nyam.everyday.module.food.repository.NutritionDetailRepository;
-import com.nyam.everyday.search.food.service.FoodSearchIndexer;
-import com.nyam.everyday.search.food.mapper.FoodSearchMapper;
-
-
-/**
- * FoodEtlService
- *
- * @author : 장소희
- * @fileName : FoodEtlService
- * @since : 25. 8. 12.
- *
- * OpenAPI -> 표준화 -> 업서트 -> 리포트
- * - 항상 per 100g 저장, ml도 1:1 가정(라벨은 원본 보존하지 않아도 되면 스킵)
- */
-
+@Slf4j
 @Service
 public class FoodEtlService {
+
+    private static final int ROWS_PER_PAGE = 50; // OpenAPI 호출 시 페이지 당 행 수
 
     private final NutriApiClient api;
     private final FoodRepository foodRepo;
     private final NutritionDetailRepository ndRepo;
     private final FoodSearchIndexer foodIndexer;
     private final FoodSearchMapper foodMapper;
+    private FoodEtlService self;
 
     public FoodEtlService(NutriApiClient api, FoodRepository foodRepo, NutritionDetailRepository ndRepo, FoodSearchIndexer foodIndexer, FoodSearchMapper foodMapper) {
         this.api = api;
         this.foodRepo = foodRepo;
         this.ndRepo = ndRepo;
         this.foodIndexer = foodIndexer;
-        this.foodMapper  = foodMapper;
+        this.foodMapper = foodMapper;
     }
 
-    @Transactional
-    public EtlReport run(int page, int rows, boolean dryRun) {
-        List<NutriApiItem> items = api.fetchItems(page, rows);
+    @Lazy
+    @Autowired
+    public void setSelf(FoodEtlService self) {
+        this.self = self;
+    }
 
-        EtlReport r = new EtlReport(page, rows, items.size());
+    // 전체 프로세스 총괄. 트랜잭션은 페이지 단위로 위임하므로 여기서는 제거.
+    public FullEtlReport runFullEtl(boolean dryRun) {
+        log.info("===== Food ETL Start (dryRun={}) =====", dryRun);
+        FullEtlReport fullReport = new FullEtlReport();
+        int currentPage = 1;
+        long totalItems = 0;
+        int totalPages = 1; // 최소 1번은 실행하기 위해 1로 시작
+
+        do {
+            NutriApiBody body;
+            try {
+                body = api.fetchItems(currentPage, ROWS_PER_PAGE);
+            } catch (Exception e) {
+                log.error("[ETL] API call failed for page {}. Stopping ETL.", currentPage, e);
+                fullReport.addErrorSample("API call failed for page " + currentPage + ": " + e.getMessage());
+                break; // API 호출 실패 시 중단
+            }
+
+            if (totalItems == 0) {
+                if (StringUtils.hasText(body.getTotalCount())) {
+                    totalItems = Long.parseLong(body.getTotalCount());
+                    totalPages = (int) Math.ceil((double) totalItems / ROWS_PER_PAGE);
+                    fullReport.setTotalItems(totalItems);
+                    fullReport.setTotalPages(totalPages);
+                }
+            }
+
+            List<NutriApiItem> items = body.getItems();
+            log.info("[ETL] Page {}/{}: Received {} items.", currentPage, totalPages, items.size());
+
+            // self-proxy를 통해 호출하여 트랜잭션 적용
+            EtlReport pageReport = self.processPage(items, dryRun);
+            fullReport.addPageReport(pageReport);
+
+            if (items.isEmpty()) {
+                log.info("[ETL] Reached last page (received 0 items).");
+                break;
+            }
+            currentPage++;
+
+        } while (currentPage <= totalPages);
+
+        if (!dryRun) {
+            try {
+                log.info("[ETL] Flushing remaining documents to Elasticsearch...");
+                foodIndexer.flush();
+                log.info("[ETL] Elasticsearch flush completed.");
+            } catch (Exception e) {
+                log.error("[ETL] Final Elasticsearch flush failed.", e);
+                fullReport.addErrorSample("[ES] Final flush failed: " + e.getMessage());
+            }
+        }
+
+        log.info("===== Food ETL Finished =====");
+        log.info("{}", fullReport);
+        return fullReport;
+    }
+
+    public EtlReport processPage(List<NutriApiItem> items, boolean dryRun) {
+        EtlReport r = new EtlReport(items.size());
         for (NutriApiItem it : items) {
             try {
-                processOne(it, dryRun, r);
+                self.processSingleItem(it, dryRun, r);
             } catch (Exception e) {
                 r.errors++;
                 r.errorSamples.add(shortItem(it) + " :: " + e.getMessage());
-            }
-        }
-        // ES 벌크 전송 (dryRun이면 생략)
-        if (!dryRun) {
-            try {
-                foodIndexer.flush();
-            } catch (Exception e) {
-                r.errors++;
-                r.errorSamples.add("[ES] flush failed: " + e.getMessage());
+                log.warn("[ETL] Failed to process item {}: {}", shortItem(it), e.getMessage(), e);
             }
         }
         return r;
     }
 
-    private void processOne(NutriApiItem it, boolean dryRun, EtlReport r) {
+    @Transactional
+    public void processSingleItem(NutriApiItem it, boolean dryRun, EtlReport r) {
         String name = safeTrim(it.getFoodNm());
-        String mfr  = emptyToNull(safeTrim(it.getMfrNm()));
-        if (name == null) { r.skippedParse++; return; }
+        String mfr = emptyToNull(safeTrim(it.getMfrNm()));
+        if (name == null) {
+            r.skippedParse++;
+            return;
+        }
 
-        // 기준량: "100g" / "100ml" -> Quantity (기본 100g)
         Quantity base = NutriConverters.parseQuantity(it.getNutConSrtrQua())
                 .orElse(new Quantity(new BigDecimal("100"), UnitKind.G));
 
-        // 1) food upsert
         Food food = upsertFood(it, name, mfr, base, dryRun, r);
 
-        // ES 버퍼에 추가 (DB upsert가 성공했을 때만)
-        if (!dryRun) {
+        if (!dryRun && food.getFoodId() != null) { // ID가 있어야만 다음 단계 진행
             try {
                 foodIndexer.add(foodMapper.from(food));
             } catch (Exception e) {
-                // 인덱싱 실패는 리포트에만 기록하고 계속 진행
                 r.errors++;
                 r.errorSamples.add("[ES] index add failed for foodId=" + food.getFoodId() + ": " + e.getMessage());
             }
-        }
 
-        // 2) nutrition_detail upsert
-        for (NutrientType nt : NutrientType.selected()) {
-            BigDecimal raw = NutriConverters.parseNumber(getFieldByName(it, nt.apiField()))
-                    .orElse(BigDecimal.ZERO);
+            for (NutrientType nt : NutrientType.selected()) {
+                BigDecimal raw = NutriConverters.parseNumber(getFieldByName(it, nt.apiField()))
+                        .orElse(BigDecimal.ZERO);
 
-            if (nt.unit() == NutrientType.Unit.MG) {
-                raw = NutriConverters.mgToG(raw); // mg -> g
+                if (nt.unit() == NutrientType.Unit.MG) {
+                    raw = NutriConverters.mgToG(raw);
+                }
+
+                BigDecimal per100g = NutriConverters.toPer100g(raw, base);
+                per100g = NutriConverters.round1(NutriConverters.clamp4_1(per100g));
+
+                upsertDetail(food.getFoodId(), nt.categoryId(), nt.label(), per100g, dryRun, r);
             }
-
-            BigDecimal per100g = NutriConverters.toPer100g(raw, base);
-            per100g = NutriConverters.round1(NutriConverters.clamp4_1(per100g));
-
-            upsertDetail(food.getFoodId(), nt.categoryId(), nt.label(), per100g, dryRun, r);
         }
     }
 
     private Food upsertFood(NutriApiItem it, String name, String mfr,
                             Quantity base, boolean dryRun, EtlReport r) {
 
-        // kcal per 100g 환산
         BigDecimal kcal = NutriConverters.parseNumber(it.getEnerc()).orElse(BigDecimal.ZERO);
         BigDecimal kcalPer100g = NutriConverters.round1(
                 NutriConverters.toPer100g(kcal, base)
         );
 
-        // 항상 100g 기준 저장
         Long unitGram = 100L;
 
-        // foodSize: g만 허용(ml → g 환산 정책 미적용)
         Integer foodSize = NutriConverters.parseQuantity(it.getFoodSize())
                 .filter(q -> q.unit() == UnitKind.G)
                 .map(q -> q.value().intValue())
                 .orElse(null);
 
-        // (food_name, manufacturer)로 조회 (manufacturer NULL 가능 → 빈문자 대체)
         Optional<Food> found =
                 foodRepo.findByFoodNameAndManufacturerNullSafe(name, nvl(mfr, ""));
 
@@ -141,21 +187,21 @@ public class FoodEtlService {
                     .foodName(name)
                     .manufacturer(mfr)
                     .unitKcal(kcalPer100g)
-                    .unitGram(unitGram)   // Long 필드
-                    .foodSize(foodSize)     // Integer 필드
+                    .unitGram(unitGram)
+                    .foodSize(foodSize)
                     .build();
 
-            if (!dryRun) foodRepo.save(f);
+            if (!dryRun) return foodRepo.save(f);
             r.inserted++;
             return f;
         } else {
             Food existed = found.get();
-            existed.setFoodName(name);          // 혹시 원본명이 바뀐 경우 동기화(선택)
-            existed.setManufacturer(mfr);       // 제조사도 동기화(선택)
+            existed.setFoodName(name);
+            existed.setManufacturer(mfr);
             existed.setUnitKcal(kcalPer100g);
             existed.setUnitGram(unitGram);
             existed.setFoodSize(foodSize);
-            if (!dryRun) foodRepo.save(existed);
+            if (!dryRun) return foodRepo.save(existed);
             r.updated++;
             return existed;
         }
@@ -173,7 +219,7 @@ public class FoodEtlService {
                     .foodCateId((long) cateId)
                     .nutritionNm(nm)
                     .amount(amount)
-                    .unitWeight(100L) // NutritionDetail이 BIGINT라면 Long 사용
+                    .unitWeight(100L)
                     .build();
 
             if (!dryRun) ndRepo.save(nd);
@@ -189,12 +235,12 @@ public class FoodEtlService {
 
     private static String getFieldByName(NutriApiItem it, String apiField) {
         return switch (apiField) {
-            case "prot"  -> it.getProt();
+            case "prot" -> it.getProt();
             case "fatce" -> it.getFatce();
-            case "chocdf"-> it.getChocdf();
+            case "chocdf" -> it.getChocdf();
             case "sugar" -> it.getSugar();
             case "fibtg" -> it.getFibtg();
-            case "nat"   -> it.getNat();
+            case "nat" -> it.getNat();
             case "chole" -> it.getChole();
             case "fasat" -> it.getFasat();
             case "fatrn" -> it.getFatrn();
@@ -202,26 +248,78 @@ public class FoodEtlService {
         };
     }
 
-    private static String safeTrim(String s) { return (s == null) ? null : s.trim(); }
-    private static String emptyToNull(String s) { return (s == null || s.isBlank()) ? null : s; }
-    private static String nvl(String s, String def) { return (s == null) ? def : s; }
+    private static String safeTrim(String s) {
+        return (s == null) ? null : s.trim();
+    }
 
-    /** 간단 리포트 */
+    private static String emptyToNull(String s) {
+        return (s == null || s.isBlank()) ? null : s;
+    }
+
+    private static String nvl(String s, String def) {
+        return (s == null) ? def : s;
+    }
+
+    private static String shortItem(NutriApiItem it) {
+        return "[" + it.getFoodCd() + "] " + it.getFoodNm();
+    }
+
     public static class EtlReport {
-        public final int page;
-        public final int rows;
         public final int received;
         public int inserted;
         public int updated;
         public int skippedParse;
         public int errors;
         public final List<String> errorSamples = new ArrayList<>();
-        public EtlReport(int page, int rows, int received) {
-            this.page = page; this.rows = rows; this.received = received;
+
+        public EtlReport(int received) {
+            this.received = received;
         }
     }
 
-    private static String shortItem(NutriApiItem it) {
-        return "[" + it.getFoodCd() + "] " + it.getFoodNm();
+    @Getter
+    public static class FullEtlReport {
+        @Setter
+        private long totalItems;
+        @Setter
+        private int totalPages;
+        private int processedPages = 0;
+        private long totalReceived = 0;
+        private long totalInserted = 0;
+        private long totalUpdated = 0;
+        private long totalSkipped = 0;
+        private long totalErrors = 0;
+        private final List<String> errorSamples = new ArrayList<>();
+
+        public void addPageReport(EtlReport report) {
+            this.processedPages++;
+            this.totalReceived += report.received;
+            this.totalInserted += report.inserted;
+            this.totalUpdated += report.updated;
+            this.totalSkipped += report.skippedParse;
+            this.totalErrors += report.errors;
+            if (!report.errorSamples.isEmpty()) {
+                this.errorSamples.addAll(report.errorSamples);
+            }
+        }
+        
+        public void addErrorSample(String error) {
+            this.totalErrors++;
+            this.errorSamples.add(error);
+        }
+
+        @Override
+        public String toString() {
+            return "FullEtlReport{" +
+                    "totalItems=" + totalItems +
+                    ", totalPages=" + totalPages +
+                    ", processedPages=" + processedPages +
+                    ", totalReceived=" + totalReceived +
+                    ", totalInserted=" + totalInserted +
+                    ", totalUpdated=" + totalUpdated +
+                    ", totalSkipped=" + totalSkipped +
+                    ", totalErrors=" + totalErrors +
+                    '}';
+        }
     }
 }

--- a/everyday/src/main/java/com/nyam/everyday/etl/web/FoodEtlAdminController.java
+++ b/everyday/src/main/java/com/nyam/everyday/etl/web/FoodEtlAdminController.java
@@ -1,9 +1,9 @@
 package com.nyam.everyday.etl.web;
 
-
 import com.nyam.everyday.etl.service.FoodEtlService;
-import com.nyam.everyday.etl.service.FoodEtlService.EtlReport;
+import com.nyam.everyday.etl.service.FoodEtlService.FullEtlReport;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -17,9 +17,10 @@ import org.springframework.web.bind.annotation.*;
  *
  * 관리자 전용 ETL 트리거 엔드포인트.
  * - 권한: ROLE_ADMIN
- * - 예: POST /api/admin/etl/foods/run?page=1&rows=100&dryRun=true
+ * - 예: POST /api/admin/etl/foods/run?dryRun=true
  */
 
+@Tag(name = "Food-Etl-Controller", description = "관리자 전용 Food Open Api ETL")
 @RestController
 @RequestMapping("/api/admin/etl/foods")
 public class FoodEtlAdminController {
@@ -30,15 +31,13 @@ public class FoodEtlAdminController {
         this.service = service;
     }
 
-    @Operation(summary = "Food ETL 실행", description = "OpenAPI에서 식품/영양소를 조회하여 DB에 업서트합니다.")
+    @Operation(summary = "Food 전체 데이터 ETL 실행", description = "OpenAPI의 모든 페이지를 순회하여 식품/영양소 데이터를 DB와 Elasticsearch에 업서트합니다.")
     @PostMapping("/run")
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<EtlReport> run(
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "100") int rows,
+    public ResponseEntity<FullEtlReport> run(
             @RequestParam(defaultValue = "false") boolean dryRun
     ) {
-        EtlReport report = service.run(page, rows, dryRun);
+        FullEtlReport report = service.runFullEtl(dryRun);
         return ResponseEntity.ok(report);
     }
 }

--- a/everyday/src/main/java/com/nyam/everyday/search/config/ElasticsearchConfig.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/config/ElasticsearchConfig.java
@@ -10,12 +10,11 @@ import org.springframework.data.elasticsearch.repository.config.EnableElasticsea
  * @fileName : ElasticsearchConfig
  * @since : 25. 8. 13.
  *
- * - spring.elasticsearch.* 설정은 application-*.yml 에서 자동 바인딩되고,
- *   여기서는 ES Repository 스캔만 활성화합니다.
+ * 이미 Spring Boot auto-config + @Document를 쓰고 있으면 없어도 동작하지만, 리포지토리 스캔 경로를 명확히 해두면 안전함
  *
  */
 
 @Configuration
-@EnableElasticsearchRepositories(basePackages = "com.nyam.everyday.search.repository")
+@EnableElasticsearchRepositories(basePackages = "com.nyam.everyday.search")
 public class ElasticsearchConfig {
 }

--- a/everyday/src/main/java/com/nyam/everyday/search/food/document/FoodDocument.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/food/document/FoodDocument.java
@@ -30,32 +30,28 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 public class FoodDocument {
 
     @Id
-    private String id;               // ES 문서 ID (RDB PK를 문자열로 써도 되고, ES가 생성해도 됨)
+    private String id;
 
-    /** 음식 이름: 한국어 형태소 분석 + 정확일치 서브필드(keyword) */
     @MultiField(
-            mainField = @Field(type = FieldType.Text,
-                    analyzer = "korean_search",
-                    searchAnalyzer = "korean_search"),
-            otherFields = {
-                    @InnerField(suffix = "keyword", type = FieldType.Keyword)
-            }
+            mainField = @Field(type = FieldType.Text, analyzer = "korean_search", searchAnalyzer = "korean_search"),
+            otherFields = { @InnerField(suffix = "keyword", type = FieldType.Keyword) }
     )
     private String foodName;
 
-    /** 제조사: 필터/정확일치 중심이면 Keyword */
+    /** 검색은 manufacturer.search(text), 필터는 manufacturer(keyword) */
     @Field(type = FieldType.Keyword)
     private String manufacturer;
 
-    /** 100g 기준 열량 (표시/정렬 등에 사용) */
-    // 매핑을 scaled_float로 만들었더라도 number 전송은 가능하므로 Double로 둬도 OK
     @Field(type = FieldType.Double)
     private Double unitKcal;
 
-    /** 기준 g (항상 100 고정으로 넣을 예정) */
     @Field(type = FieldType.Long)
     private Long unitGram;
 
     @Field(type = FieldType.Integer)
     private Integer foodSize;
+
+    /** copy_to 대상으로만 쓰는 통합 검색 필드 (명시 보관용) */
+    @Field(type = FieldType.Text, analyzer = "korean_search", searchAnalyzer = "korean_search")
+    private String all_search;
 }

--- a/everyday/src/main/java/com/nyam/everyday/search/food/dto/FoodSearchItem.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/food/dto/FoodSearchItem.java
@@ -1,0 +1,21 @@
+package com.nyam.everyday.search.food.dto;
+
+import lombok.Builder;
+
+/**
+ * FoodSearchItem
+ *
+ * @author : 장소희
+ * @fileName : FoodSearchItem
+ * @since : 25. 8. 15.
+ */
+
+@Builder
+public record FoodSearchItem(
+        String id,
+        String foodName,
+        String manufacturer,
+        Double unitKcal,
+        Long unitGram,
+        Integer foodSize
+) {}

--- a/everyday/src/main/java/com/nyam/everyday/search/food/dto/FoodSearchRequest.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/food/dto/FoodSearchRequest.java
@@ -1,0 +1,32 @@
+package com.nyam.everyday.search.food.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.Builder;
+
+/**
+ * FoodSearchRequest
+ *
+ * @author : 장소희
+ * @fileName : FoodSearchRequest
+ * @since : 25. 8. 15.
+ */
+
+
+@Builder
+public record FoodSearchRequest(
+        String q,                 // 검색어 (식품명/제조사 동시)
+        String manufacturer,      // 제조사 필터(정확일치, 선택)
+        @Min(0) int page,
+        @Min(1) int size,
+        String sort               // 예: "score,desc" or "unitKcal,asc"
+) {
+    public static FoodSearchRequest of(String q, String manufacturer, Integer page, Integer size, String sort) {
+        return FoodSearchRequest.builder()
+                .q(q)
+                .manufacturer(manufacturer)
+                .page(page == null ? 0 : page)
+                .size(size == null ? 10 : size)
+                .sort(sort == null ? "score,desc" : sort)
+                .build();
+    }
+}

--- a/everyday/src/main/java/com/nyam/everyday/search/food/dto/FoodSearchResponse.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/food/dto/FoodSearchResponse.java
@@ -1,0 +1,22 @@
+package com.nyam.everyday.search.food.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * FoodSearchResponse
+ *
+ * @author : 장소희
+ * @fileName : FoodSearchResponse
+ * @since : 25. 8. 15.
+ */
+
+@Builder
+public record FoodSearchResponse(
+        List<FoodSearchItem> content,
+        long totalElements,
+        int totalPages,
+        int page,
+        int size
+) {}

--- a/everyday/src/main/java/com/nyam/everyday/search/food/dto/FoodSuggestionResponse.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/food/dto/FoodSuggestionResponse.java
@@ -1,0 +1,12 @@
+package com.nyam.everyday.search.food.dto;
+
+import java.util.List;
+
+/**
+ * FoodSuggestionResponse
+ *
+ * @author : 장소희
+ * @fileName : FoodSuggestionResponse
+ * @since : 25. 8. 15.
+ */
+public record FoodSuggestionResponse(List<String> suggestions) {}

--- a/everyday/src/main/java/com/nyam/everyday/search/food/mapper/FoodSearchMapper.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/food/mapper/FoodSearchMapper.java
@@ -2,7 +2,14 @@ package com.nyam.everyday.search.food.mapper;
 
 import com.nyam.everyday.module.food.entity.Food;
 import com.nyam.everyday.search.food.document.FoodDocument;
-import org.mapstruct.*;
+import com.nyam.everyday.search.food.dto.FoodSearchItem;
+import com.nyam.everyday.search.food.dto.FoodSearchResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
 
 /**
  * FoodSearchMapper
@@ -12,14 +19,39 @@ import org.mapstruct.*;
  * @since : 25. 8. 13.
  */
 
-@Mapper(componentModel = "spring")
+@Mapper(
+        componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE // 불필요 매핑 경고 억제(선택)
+)
 public interface FoodSearchMapper {
 
-    @Mapping(target = "id",        expression = "java(food.getFoodId() == null ? null : String.valueOf(food.getFoodId()))")
-    @Mapping(target = "foodName",  source = "foodName")
+    // --- 검색 응답: Document -> DTO ---
+    FoodSearchItem toItem(FoodDocument doc);
+
+    default FoodSearchResponse toPageResponse(Page<FoodDocument> page) {
+        List<FoodSearchItem> items = page.getContent().stream()
+                .map(this::toItem)
+                .toList();
+        return new FoodSearchResponse(
+                items,
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getNumber(),
+                page.getSize()
+        );
+    }
+
+    // --- 인덱싱: Entity -> Document ---
+    @Mapping(target = "id",
+            expression = "java(food.getFoodId() == null ? null : String.valueOf(food.getFoodId()))")
+    @Mapping(target = "foodName", source = "foodName")
     @Mapping(target = "manufacturer", source = "manufacturer")
-    @Mapping(target = "unitKcal",  expression = "java(food.getUnitKcal() == null ? null : food.getUnitKcal().doubleValue())")
-    @Mapping(target = "unitGram", expression = "java(food.getUnitGram() == null ? null : Long.valueOf(food.getUnitGram()))")
-    @Mapping(target = "foodSize",  source = "foodSize")
+    // BigDecimal -> Double null-safe 변환 (FoodDocument.unitKcal가 Double라고 가정)
+    @Mapping(target = "unitKcal",
+            expression = "java(food.getUnitKcal() == null ? null : food.getUnitKcal().doubleValue())")
+    @Mapping(target = "unitGram", source = "unitGram") // Long -> Long
+    @Mapping(target = "foodSize", source = "foodSize") // Integer -> Integer
+    // ❗ 현재 매핑/Document에 all_search 없으면 아래 라인 제거
+    // @Mapping(target = "all_search", ignore = true)
     FoodDocument from(Food food);
 }

--- a/everyday/src/main/java/com/nyam/everyday/search/food/repository/FoodSearchRepository.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/food/repository/FoodSearchRepository.java
@@ -11,6 +11,6 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
  * @since : 25. 8. 13.
  */
 
-public interface FoodSearchRepository extends ElasticsearchRepository<FoodDocument, String> {
-
+public interface FoodSearchRepository extends ElasticsearchRepository<FoodDocument, String>, FoodSearchRepositoryCustom {
+    // 필요하면 메소드 쿼리 추가 가능
 }

--- a/everyday/src/main/java/com/nyam/everyday/search/food/repository/FoodSearchRepositoryCustom.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/food/repository/FoodSearchRepositoryCustom.java
@@ -1,0 +1,20 @@
+package com.nyam.everyday.search.food.repository;
+
+import com.nyam.everyday.search.food.document.FoodDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+/**
+ * FoodSearchRepositoryCustom
+ *
+ * @author : 장소희
+ * @fileName : FoodSearchRepositoryCustom
+ * @since : 25. 8. 15.
+ */
+
+public interface FoodSearchRepositoryCustom {
+    Page<FoodDocument> search(String q, String manufacturer, Pageable pageable, String sort);
+    List<String> suggestPrefix(String prefix, int size);
+}

--- a/everyday/src/main/java/com/nyam/everyday/search/food/repository/FoodSearchRepositoryImpl.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/food/repository/FoodSearchRepositoryImpl.java
@@ -1,0 +1,94 @@
+/**
+ * FoodSearchRepositoryImpl
+ *
+ * @author : 장소희
+ * @fileName : FoodSearchRepositoryImpl
+ * @since : 25. 8. 15.
+ */
+
+package com.nyam.everyday.search.food.repository;
+
+import com.nyam.everyday.search.food.document.FoodDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.data.elasticsearch.core.*;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class FoodSearchRepositoryImpl implements FoodSearchRepositoryCustom {
+
+    private final ElasticsearchOperations operations;
+
+    @Override
+    public Page<FoodDocument> search(String q, String manufacturer, Pageable pageable, String sort) {
+        // 정렬 (_score 기본)
+        Sort esSort = Sort.by(Sort.Order.desc("_score"));
+        if (sort != null && !sort.isBlank()) {
+            String[] parts = sort.split(",");
+            String field = parts[0].trim();
+            Sort.Direction dir = (parts.length > 1 && "asc".equalsIgnoreCase(parts[1]))
+                    ? Sort.Direction.ASC : Sort.Direction.DESC;
+            esSort = "score".equalsIgnoreCase(field)
+                    ? Sort.by(Sort.Order.by("_score").with(dir))
+                    : Sort.by(new Sort.Order(dir, field));
+        }
+
+        Criteria criteria = new Criteria();
+        boolean hasShould = false;
+
+        if (q != null && !q.isBlank()) {
+            // 1) 형태소 기반 match (foodName)
+            Criteria c1 = new Criteria("foodName").matches(q);
+
+            // 2) 제조사 텍스트 매치(형태소/standard로 저장되어 있으면 matches, keyword면 contains/startsWith에 맞춤)
+            Criteria c2 = new Criteria("manufacturer").matches(q);
+
+            // 3) 접두 매치: 전체 문자열 기준(prefix) -> keyword 서브필드 사용
+            Criteria c3 = new Criteria("foodName.keyword").startsWith(q);
+
+            // should 조합 (minimum_should_match = 1 효과)
+            criteria = c1.or(c2).or(c3);
+            hasShould = true;
+        }
+
+        if (manufacturer != null && !manufacturer.isBlank()) {
+            // 정확 필터 필요 시 여기에 and 조건 (지금은 manufacturer 필터 안 쓸 거면 생략 가능)
+            criteria = (hasShould ? criteria : new Criteria()).and(
+                    new Criteria("manufacturer").is(manufacturer)
+            );
+        }
+
+        CriteriaQuery query = new CriteriaQuery(criteria);
+        query.setPageable(PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), esSort));
+
+        SearchHits<FoodDocument> hits = operations.search(query, FoodDocument.class, IndexCoordinates.of("food"));
+        List<FoodDocument> content = hits.stream().map(SearchHit::getContent).toList();
+        long total = hits.getTotalHits();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public List<String> suggestPrefix(String prefix, int size) {
+        if (prefix == null || prefix.isBlank()) return List.of();
+
+        // 자동완성: 접두 우선 — keyword 서브필드로 빠르게
+        CriteriaQuery query = new CriteriaQuery(
+                new Criteria("foodName.keyword").startsWith(prefix)
+        );
+        query.setPageable(PageRequest.of(0, size));
+        SearchHits<FoodDocument> hits = operations.search(query, FoodDocument.class, IndexCoordinates.of("food"));
+
+        return hits.stream()
+                .map(h -> h.getContent().getFoodName())
+                .distinct()
+                .limit(size)
+                .toList();
+    }
+}

--- a/everyday/src/main/java/com/nyam/everyday/search/food/service/FoodSearchIndexer.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/food/service/FoodSearchIndexer.java
@@ -1,8 +1,12 @@
 package com.nyam.everyday.search.food.service;
 
 import com.nyam.everyday.search.food.document.FoodDocument;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -15,17 +19,32 @@ import java.util.List;
  * @fileName : FoodSearchIndexer
  * @since : 25. 8. 13.
  */
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FoodSearchIndexer {
 
     private final ElasticsearchOperations operations;
 
-    private static final int BULK_THRESHOLD = 500;
+    private static final int BULK_THRESHOLD = 1500;
+
     private final List<FoodDocument> buffer = new ArrayList<>();
 
-    /** ETL 동안 계속 호출: 메모리 버퍼에 쌓음, 임계치 넘으면 즉시 flush */
+    @PostConstruct
+    void initIndex() {
+        IndexOperations io = operations.indexOps(FoodDocument.class);
+        if (!io.exists()) {
+            log.info("[ES] 'food' 인덱스가 없어 생성합니다.");
+            // @Setting/@Mapping을 FoodDocument에 달아뒀다면 create() 가 그 설정을 사용
+            io.create();
+            io.putMapping(io.createMapping(FoodDocument.class));
+            log.info("[ES] 'food' 인덱스 생성 완료.");
+        } else {
+            log.info("[ES] 'food' 인덱스가 이미 존재합니다.");
+        }
+    }
+
+    /** ETL 중 계속 호출: 메모리 버퍼에 쌓고 임계치 넘으면 즉시 flush */
     public synchronized void add(FoodDocument doc) {
         if (doc == null) return;
         buffer.add(doc);
@@ -34,10 +53,24 @@ public class FoodSearchIndexer {
         }
     }
 
-    /** 루프 끝에서 한 번 호출: 남은 것 모두 저장 */
+    /** 남은 것 모두 저장 + refresh(테스트/즉시검색용) */
     public synchronized void flush() {
         if (buffer.isEmpty()) return;
-        operations.save(buffer);        // @Document의 indexName("food") 기준으로 벌크 저장
-        buffer.clear();
+        try {
+            log.info("[ES] bulk indexing {} docs...", buffer.size());
+            operations.save(buffer);                  // @Document(indexName="food") 기반 벌크 저장
+            operations.indexOps(FoodDocument.class).refresh(); // 바로 검색 가능하게
+            log.info("[ES] bulk indexing done.");
+        } catch (Exception e) {
+            log.error("[ES] bulk indexing 실패", e);
+        } finally {
+            buffer.clear();
+        }
+    }
+
+    @PreDestroy
+    void onShutdown() {
+        // 앱 종료 시 잔여 버퍼 밀어넣기
+        flush();
     }
 }

--- a/everyday/src/main/java/com/nyam/everyday/search/food/service/FoodSearchService.java
+++ b/everyday/src/main/java/com/nyam/everyday/search/food/service/FoodSearchService.java
@@ -1,0 +1,36 @@
+package com.nyam.everyday.search.food.service;
+
+
+import com.nyam.everyday.search.food.dto.*;
+import com.nyam.everyday.search.food.mapper.FoodSearchMapper;
+import com.nyam.everyday.search.food.repository.FoodSearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+/**
+ * FoodSearchService
+ *
+ * @author : 장소희
+ * @fileName : FoodSearchService
+ * @since : 25. 8. 15.
+ */
+
+@Service
+@RequiredArgsConstructor
+public class FoodSearchService {
+
+    private final FoodSearchRepository repository;
+    private final FoodSearchMapper mapper;
+
+    public FoodSearchResponse search(FoodSearchRequest req) {
+        var pageable = PageRequest.of(req.page(), req.size());
+        var page = repository.search(req.q(), req.manufacturer(), pageable, req.sort());
+        return mapper.toPageResponse(page);
+    }
+
+    public FoodSuggestionResponse suggest(String prefix, Integer size) {
+        var list = repository.suggestPrefix(prefix, size == null ? 10 : size);
+        return new FoodSuggestionResponse(list);
+    }
+}

--- a/everyday/src/main/java/com/nyam/everyday/web/food/FoodSearchController.java
+++ b/everyday/src/main/java/com/nyam/everyday/web/food/FoodSearchController.java
@@ -1,0 +1,125 @@
+package com.nyam.everyday.web.food;
+
+import com.nyam.everyday.search.food.dto.FoodSearchRequest;
+import com.nyam.everyday.search.food.dto.FoodSearchResponse;
+import com.nyam.everyday.search.food.dto.FoodSuggestionResponse;
+import com.nyam.everyday.search.food.service.FoodSearchService;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+/**
+ * FoodSearchController
+ *
+ * @author : 장소희
+ * @fileName : FoodSearchController
+ * @since : 25. 8. 15.
+ */
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/food/search")
+@Validated
+@Tag(name = "Food Search", description = "식품 검색 및 자동완성 API")
+public class FoodSearchController {
+
+    private static final int MAX_PAGE_SIZE = 50;
+
+    private final FoodSearchService service;
+
+    @GetMapping
+    @Operation(
+            summary = "식품 검색",
+            description = "검색어(q) 하나로 식품명과 제조사를 동시에 검색합니다. 제조사 별 필터는 없습니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "검색 성공")
+            }
+    )
+    public FoodSearchResponse search(
+
+            @Parameter(description = "검색어(식품명/제조사 동시 검색)", example = "샐러드")
+            @RequestParam(required = false)
+            String q,
+
+            @Parameter(description = "페이지 번호(0-base)", example = "0", schema = @Schema(minimum = "0"))
+            @RequestParam(defaultValue = "0") @Min(0)
+            Integer page,
+
+            @Parameter(description = "페이지 크기(최대 50)", example = "10", schema = @Schema(minimum = "1", maximum = "50"))
+            @RequestParam(defaultValue = "10") @Min(1)
+            Integer size,
+
+            @Parameter(description = "정렬, 예) score,desc | unitKcal,asc", example = "score,desc")
+            @RequestParam(defaultValue = "score,desc")
+            String sort
+    ) {
+        q = normalize(q);
+        size = Math.min(size, MAX_PAGE_SIZE);
+        sort = sanitizeSort(sort);
+
+        // manufacturer는 사용하지 않으므로 null로 고정
+        var req = FoodSearchRequest.of(q, null, page, size, sort);
+        return service.search(req);
+    }
+
+    @GetMapping("/suggest")
+    @Operation(
+            summary = "자동완성",
+            description = "검색어 접두(prefix)에 맞는 식품명 후보를 반환합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "추천 성공")
+            }
+    )
+    public FoodSuggestionResponse suggest(
+            @Parameter(description = "자동완성 접두어", example = "샐")
+            @RequestParam String prefix,
+
+            @Parameter(description = "최대 개수(최대 50)", example = "10", schema = @Schema(minimum = "1", maximum = "50"))
+            @RequestParam(defaultValue = "10") @Min(1)
+            Integer size
+    ) {
+        prefix = normalize(prefix);
+        size = Math.min(size, MAX_PAGE_SIZE);
+        return service.suggest(prefix, size);
+    }
+
+    // ---- helpers ------------------------------------------------------------
+
+    /** 공백 정리 + 빈 문자열이면 null 로 변환 */
+    private String normalize(String s) {
+        if (s == null) return null;
+        String t = s.trim();
+        return t.isEmpty() ? null : t;
+    }
+
+    /** 허용된 필드만 통과시키는 간단한 정렬 파라미터 정제 */
+    private String sanitizeSort(String sort) {
+        if (sort == null || sort.isBlank()) return "score,desc";
+        String[] parts = sort.split(",");
+        String field = parts[0].trim();
+        String dir = (parts.length > 1 ? parts[1].trim().toLowerCase() : "desc");
+
+        // 허용 필드 화이트리스트
+        switch (field) {
+            case "score":
+            case "unitKcal":
+            case "unitGram":
+            case "foodSize":
+                break;
+            default:
+                field = "score";
+        }
+
+        if (!dir.equals("asc") && !dir.equals("desc")) {
+            dir = "desc";
+        }
+        return field + "," + dir;
+    }
+}

--- a/everyday/src/main/resources/application-local.yml
+++ b/everyday/src/main/resources/application-local.yml
@@ -106,3 +106,5 @@ openapi:
     base-url: http://api.data.go.kr/openapi/tn_pubr_public_nutri_process_info_api
     service-key: ${NUTRI_API_KEY}   # 환경변수에서 주입
     default-page-size: 100
+    connect-timeout: 5s
+    read-timeout: 120s

--- a/everyday/src/main/resources/elasticsearch/food-mappings.json
+++ b/everyday/src/main/resources/elasticsearch/food-mappings.json
@@ -4,11 +4,25 @@
       "type": "text",
       "analyzer": "korean_search",
       "search_analyzer": "korean_search",
+      "copy_to": ["all_search"],
+      "fields": { "keyword": { "type": "keyword" } }
+    },
+    "manufacturer": {
+      "type": "keyword",
       "fields": {
-        "keyword": { "type": "keyword" }
+        "search": {
+          "type": "text",
+          "analyzer": "korean_search",
+          "search_analyzer": "korean_search",
+          "copy_to": ["all_search"]
+        }
       }
     },
-    "manufacturer": { "type": "keyword" },
+    "all_search": {
+      "type": "text",
+      "analyzer": "korean_search",
+      "search_analyzer": "korean_search"
+    },
     "unitKcal": { "type": "double" },
     "unitGram": { "type": "long" },
     "foodSize": { "type": "integer" }


### PR DESCRIPTION
## 💭 작업 브랜치
feature/elastic-food

## 🍀 기능 설명
OpenAPI에서 페이지 단위로 가져오던 식품 데이터를 전체 페이지 반복 호출 방식으로 변경하여,
RDB와 Elasticsearch에 모든 데이터를 저장할 수 있도록 수정 및 
음식 검색에 elastic search 적용

## 관련된 Issue
close #73 