### PR TITLE
Feature/#128 챌린지 관련 API 추가

### DIFF
--- a/everyday/src/main/java/com/nyam/everyday/module/boardLike/service/BoardLikeService.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/boardLike/service/BoardLikeService.java
@@ -7,11 +7,15 @@ import com.nyam.everyday.module.board.entity.Board;
 import com.nyam.everyday.module.board.repository.BoardRepository;
 import com.nyam.everyday.module.boardLike.entity.BoardLike;
 import com.nyam.everyday.module.boardLike.repository.BoardLikeRepository;
+import com.nyam.everyday.module.challenge.checker.event.event.ChallengeCheckEvent;
+import com.nyam.everyday.module.challenge.entity.ChallengeTag;
 import com.nyam.everyday.module.member.entity.Member;
 import com.nyam.everyday.module.member.repository.MemberRepository;
 import com.nyam.everyday.web.boardlike.dto.BoardLikeResponseDto;
 import com.nyam.everyday.web.boardlike.mapper.BoardLikeMapper;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +28,7 @@ public class BoardLikeService {
   private final BoardRepository boardRepository;
   private final MemberRepository memberRepository;
   private final BoardLikeMapper boardLikeMapper;
+  private final ApplicationEventPublisher publisher;
 
 
   //토글 메서드로 진행한 좋아요
@@ -50,6 +55,9 @@ public class BoardLikeService {
 
     long likeCount = boardLikeRepository.countByBoard(board);
     board.updateLikeCount(likeCount); // or setLikeCount
+
+    // 좋아요 눌렀으니, 이벤트 발행
+    publisher.publishEvent(new ChallengeCheckEvent(memberId, ChallengeTag.LIKE, LocalDate.now()));
 
     return BoardLikeResponseDto.builder()
         .likeId(likeId)          // ← 생성된 경우만 값이 들어감, 취소면 null

--- a/everyday/src/main/java/com/nyam/everyday/module/challenge/checker/event/listener/ChallengeClearedListener.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/challenge/checker/event/listener/ChallengeClearedListener.java
@@ -4,7 +4,7 @@ import static org.springframework.transaction.annotation.Propagation.REQUIRES_NE
 
 import com.nyam.everyday.module.badge.service.BadgeService;
 import com.nyam.everyday.module.challenge.checker.event.event.ChallengeClearedEvent;
-import com.nyam.everyday.module.challenge.checker.service.MemberChallengeStatusService;
+import com.nyam.everyday.module.challenge.service.MemberChallengeStatusService;
 import com.nyam.everyday.module.challenge.entity.Challenge;
 import com.nyam.everyday.module.challenge.entity.MemberChallengeStatus;
 import com.nyam.everyday.module.member.entity.Member;
@@ -60,7 +60,7 @@ public class ChallengeClearedListener {
     badgeService.assignBadgeToMember(member.getMemberId(), badgeDto);
 
     // 사용자에게 알림 전송
-    notificationService.addPrivateNotification(challenge.getTitle() + " 챌린지를 달성해 뱃지를 획득헀습니다.",
+    notificationService.addPrivateNotification(challenge.getTitle() + "를 달성해 뱃지를 획득헀습니다.",
         member.getMemberId(), NotificationType.CHALLENGE_CLEAR);
 
     // 1. 멤버가 '활동 중'인 모든 팀의 ID를 TeamMemberService를 통해 조회

--- a/everyday/src/main/java/com/nyam/everyday/module/challenge/checker/event/listener/MCDCreateListener.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/challenge/checker/event/listener/MCDCreateListener.java
@@ -2,8 +2,8 @@ package com.nyam.everyday.module.challenge.checker.event.listener;
 
 import com.nyam.everyday.module.challenge.checker.event.event.MCDCreateEvent;
 import com.nyam.everyday.module.challenge.checker.event.event.ProgressRecomputeEvent;
-import com.nyam.everyday.module.challenge.checker.service.ChallengeCheckService;
 import com.nyam.everyday.module.challenge.entity.Challenge;
+import com.nyam.everyday.module.challenge.service.MemberChallengeDayService;
 import com.nyam.everyday.module.member.entity.Member;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MCDCreateListener {
 
-  private final ChallengeCheckService challengeCheckService;
+  private final MemberChallengeDayService memberChallengeDayService;
   private final ApplicationEventPublisher publisher;
 
   @EventListener
@@ -31,7 +31,7 @@ public class MCDCreateListener {
     LocalDate targetDate = event.getTargetDate();
 
     // 해당 일자에 해당하는 MemberChallengeDay를 만든다.
-    challengeCheckService.addMemberChallengeDay(member, challenge, targetDate);
+    memberChallengeDayService.addMemberChallengeDay(member, challenge, targetDate);
 
     // 진행도를 다시 체크하도록 이벤트를 발행한다
     publisher.publishEvent(new ProgressRecomputeEvent(member, challenge));

--- a/everyday/src/main/java/com/nyam/everyday/module/challenge/checker/event/listener/MCDDeleteListener.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/challenge/checker/event/listener/MCDDeleteListener.java
@@ -4,6 +4,7 @@ import com.nyam.everyday.module.challenge.checker.event.event.MCDDeleteEvent;
 import com.nyam.everyday.module.challenge.checker.event.event.ProgressRecomputeEvent;
 import com.nyam.everyday.module.challenge.checker.service.ChallengeCheckService;
 import com.nyam.everyday.module.challenge.entity.Challenge;
+import com.nyam.everyday.module.challenge.service.MemberChallengeDayService;
 import com.nyam.everyday.module.member.entity.Member;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MCDDeleteListener {
 
-  private final ChallengeCheckService challengeCheckService;
+  private final MemberChallengeDayService memberChallengeDayService;
   private final ApplicationEventPublisher publisher;
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -30,7 +31,7 @@ public class MCDDeleteListener {
     LocalDate targetDate = event.getTargetDate();
 
     // 해당 일자에 해당하는 mcd를 삭제한다.
-    challengeCheckService.deleteMemberChallengeDay(member, challenge, targetDate);
+    memberChallengeDayService.deleteMemberChallengeDay(member, challenge, targetDate);
 
     // 진행도를 다시 체크하도록 이벤트를 발행한다
     publisher.publishEvent(new ProgressRecomputeEvent(member, challenge));

--- a/everyday/src/main/java/com/nyam/everyday/module/challenge/checker/event/listener/ProgressRecomputeListener.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/challenge/checker/event/listener/ProgressRecomputeListener.java
@@ -32,7 +32,7 @@ public class ProgressRecomputeListener {
   private final ApplicationEventPublisher publisher;
 
   @Transactional(propagation = REQUIRES_NEW)
-  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
   public void progressRecompute(ProgressRecomputeEvent progressRecomputeEvent) {
     log.info("ProgressRecompute 동작");
     Member member = progressRecomputeEvent.getMember();

--- a/everyday/src/main/java/com/nyam/everyday/module/challenge/checker/service/ChallengeCheckService.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/challenge/checker/service/ChallengeCheckService.java
@@ -57,40 +57,6 @@ public class ChallengeCheckService {
   }
 
   /**
-   * 멤버, 챌린지, 날짜에 적절한 MemberChallengeDay 데이터를 생성합니다, 이미 같은 값이 존재한다면, 수행하지 않습니다.
-   *
-   * @param member    회원
-   * @param challenge 대상 챌린지
-   * @param date      챌린지 진행 날짜
-   */
-  public void addMemberChallengeDay(Member member, Challenge challenge, LocalDate date) {
-    if (!memberChallengeDayRepository.existsByMember_MemberIdAndChallenge_IdAndTargetDate(
-        member.getMemberId(), challenge.getId(), date)) {
-      memberChallengeDayRepository.save(MemberChallengeDay.builder()
-          .member(member)
-          .challenge(challenge)
-          .targetDate(date)
-          .build()
-      );
-    }
-  }
-
-  /**
-   * 멤버, 챌린지, 날짜에 적절한 MemberChallengeDay 데이터를 삭제합니다(진행 취소 처리) 데이터가 존재하지 않는다면, 수행하지 않습니다.
-   *
-   * @param member    회원
-   * @param challenge 대상 챌린지
-   * @param date      챌린지 진행 날짜
-   */
-  public void deleteMemberChallengeDay(Member member, Challenge challenge, LocalDate date) {
-    if (memberChallengeDayRepository.existsByMember_MemberIdAndChallenge_IdAndTargetDate(
-        member.getMemberId(), challenge.getId(), date)) {
-      memberChallengeDayRepository.deleteMemberChallengeDay(member.getMemberId(), challenge.getId(),
-          date);
-    }
-  }
-
-  /**
    * 챌린지 태그에 해당하는 Challnge 정보를 불러옵니다.
    *
    * @param challengeCode 찾고자 하는 챌린지 코드

--- a/everyday/src/main/java/com/nyam/everyday/module/challenge/checker/service/ProgressComputeService.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/challenge/checker/service/ProgressComputeService.java
@@ -5,6 +5,7 @@ import com.nyam.everyday.module.challenge.checker.registry.ChallengeCheckerRegis
 import com.nyam.everyday.module.challenge.entity.Challenge;
 import com.nyam.everyday.module.challenge.entity.MemberChallengeStatus;
 import com.nyam.everyday.module.challenge.repository.MemberChallengeDayRepository;
+import com.nyam.everyday.module.challenge.service.MemberChallengeStatusService;
 import com.nyam.everyday.module.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/everyday/src/main/java/com/nyam/everyday/module/challenge/repository/ChallengeRepository.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/challenge/repository/ChallengeRepository.java
@@ -3,12 +3,16 @@ package com.nyam.everyday.module.challenge.repository;
 import com.nyam.everyday.module.challenge.entity.Challenge;
 import com.nyam.everyday.module.challenge.entity.ChallengeCode;
 import com.nyam.everyday.module.challenge.entity.ChallengeTag;
+import com.nyam.everyday.module.challenge.entity.ChallengeType;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
   Challenge getByChallengeCode(ChallengeCode challengeCode);
 
-  List<Challenge> getAllByType(ChallengeTag challengeTag);
+  List<Challenge> getAllByType(ChallengeType challengeType);
+
+  List<Challenge> findAll();
 }

--- a/everyday/src/main/java/com/nyam/everyday/module/challenge/repository/MemberChallengeStatusRepository.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/challenge/repository/MemberChallengeStatusRepository.java
@@ -19,4 +19,9 @@ public interface MemberChallengeStatusRepository extends JpaRepository<MemberCha
       + "FROM MemberChallengeStatus mcs "
       + "WHERE mcs.member.memberId = :memberId AND mcs.challenge.id = :challengeId")
   Optional<Boolean> getIsCleared(Long memberId, Long challengeId);
+
+  @Query("SELECT mcs.progressCount "
+      + "FROM MemberChallengeStatus mcs "
+      + "WHERE mcs.member.memberId = :memberId AND mcs.challenge.id = :challengeId")
+  Optional<Long> getProgressCount(Long memberId, Long challengeId);
 }

--- a/everyday/src/main/java/com/nyam/everyday/module/challenge/service/ChallengeService.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/challenge/service/ChallengeService.java
@@ -1,0 +1,140 @@
+package com.nyam.everyday.module.challenge.service;
+
+import com.nyam.everyday.module.challenge.entity.Challenge;
+import com.nyam.everyday.module.challenge.entity.ChallengeType;
+import com.nyam.everyday.module.challenge.repository.ChallengeRepository;
+import com.nyam.everyday.web.challenge.dto.ChallengeDto;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeService {
+
+  private final ChallengeRepository challengeRepository;
+  private final MemberChallengeStatusService mcsService;
+
+  /**
+   * 사용자가 현재 진행 중이며 아직 완료하지 못한 챌린지 목록을 조회합니다.
+   *
+   * <p>구현 예정: MemberChallengeStatus 기준으로 진행 중 판별 후 Challenge를 모아 DTO로 변환합니다.</p>
+   *
+   * @param memberId 조회 대상 회원의 식별자
+   * @return 진행 중인 챌린지의 DTO 목록
+   */
+  // 상시 챌린지 리스트에 표시될 리스트를 전달한다.
+  public List<ChallengeDto> getProgressingChallenge(Long memberId) {
+    // 유저가 진행중이면서, 아직 완료하지 못한 챌린지를 n개 제공한다.
+    List<Challenge> challenges = challengeRepository.findAll();
+    List<ChallengeDto> dtos = this.makeChallengeToDto(memberId, challenges);
+
+    List<ChallengeDto> result = new ArrayList<>();
+    // 진행도가 0이 아닌 챌린지 최대 2개까지
+    for (ChallengeDto dto : dtos) {
+      if (result.size() > 2) {
+        break;
+      }
+      if (dto.getProgressCount() == 0) {
+        break;
+      }
+
+      result.add(dto);
+    }
+
+    return result;
+  }
+
+  /**
+   * 상시(정규) 챌린지 전체 목록을 조회해 사용자의 진행 상황을 포함한 DTO로 반환합니다.
+   *
+   * <p>ChallengeType.REGULAR_CHALLENGE 에 해당하는 엔티티를 조회하고
+   * 각 챌린지에 대해 완료 여부와 진행 개수를 조회한 뒤 DTO로 변환합니다.</p>
+   *
+   * @param memberId 진행 상황을 함께 계산할 회원의 식별자
+   * @return 상시 챌린지 DTO 목록
+   */
+  public List<ChallengeDto> getRegularChallengeList(Long memberId) {
+    // 먼저 모든 챌린지 리스트를 가져온다.
+    List<Challenge> challenges = challengeRepository.getAllByType(ChallengeType.REGULAR_CHALLENGE);
+    // Dto로 변환한다.
+    List<ChallengeDto> result = this.makeChallengeToDto(memberId, challenges);
+    // 반환
+    return result;
+  }
+
+  /**
+   * 이벤트성 챌린지 전체 목록을 조회해 사용자의 진행 상황을 포함한 DTO로 반환합니다.
+   *
+   * <p>ChallengeType.EVENT_CHALLENGE 에 해당하는 엔티티를 조회하고
+   * 각 챌린지에 대해 완료 여부와 진행 개수를 조회한 뒤 DTO로 변환합니다.</p>
+   *
+   * @param memberId 진행 상황을 함께 계산할 회원의 식별자
+   * @return 이벤트 챌린지 DTO 목록
+   */
+  public List<ChallengeDto> getEventChallengeList(Long memberId) {
+    // 먼저 모든 챌린지 리스트를 가져온다.
+    List<Challenge> challenges = challengeRepository.getAllByType(ChallengeType.EVENT_CHALLENGE);
+    // Dto로 변환한다.
+    List<ChallengeDto> result = this.makeChallengeToDto(memberId, challenges);
+    // 반환
+    return result;
+  }
+
+
+  /**
+   * Challenge 엔티티 리스트를 사용자의 진행 상황을 반영한 ChallengeDto 리스트로 변환합니다.
+   *
+   * @param memberId   진행 상황을 조회할 회원 식별자
+   * @param challenges 변환 대상 챌린지 엔티티 목록
+   * @return 변환된 ChallengeDto 목록
+   */
+  private List<ChallengeDto> makeChallengeToDto(Long memberId, List<Challenge> challenges) {
+    List<ChallengeDto> result = new ArrayList<>();
+
+    // 각 챌린지별 Dto 만들기
+    for (Challenge challenge : challenges) {
+      // 유저의 챌린지 완료 여부를 불러온다.
+      boolean isCleared = mcsService.getIsCleared(memberId, challenge.getId());
+      Long progressCount = mcsService.getProgressCount(memberId, challenge.getId());
+
+      // null-safe LocalDate 변환
+      java.time.LocalDate startDate = challenge.getStartDate() != null
+          ? challenge.getStartDate().toLocalDate()
+          : null;
+      java.time.LocalDate endDate = challenge.getEndDate() != null
+          ? challenge.getEndDate().toLocalDate()
+          : null;
+
+      // Dto 생성해서, result에 집어넣는다
+      result.add(ChallengeDto.builder()
+          .title(challenge.getTitle())
+          .description(challenge.getDescription())
+          .cleared(isCleared)
+          .targetCount(challenge.getTargetCount())
+          .progressCount(progressCount)
+          .startDate(startDate)
+          .endDate(endDate)
+          .build()
+      );
+    }
+
+    // 진행도 기반 정렬한다
+    // 1) 아직 안 깬 챌린지(false)가 먼저, 이미 깬 챌린지(true)는 아래로
+    // 2) 같은 그룹 내에서는 진행률(= progressCount / targetCount) 내림차순
+    result.sort(
+        java.util.Comparator
+            .comparingInt((ChallengeDto d) -> d.isCleared() ? 1 : 0) // false(0) 먼저 true(1) 나중
+            .thenComparing(
+                java.util.Comparator.<ChallengeDto>comparingDouble(d -> {
+                  long p = d.getProgressCount() == null ? 0L : d.getProgressCount();
+                  long t = d.getTargetCount()   == null ? 0L : d.getTargetCount();
+                  return t <= 0 ? 0.0 : (double) p / (double) t;
+                }).reversed()
+            )
+    );
+
+    return result;
+  }
+}

--- a/everyday/src/main/java/com/nyam/everyday/module/challenge/service/MemberChallengeDayService.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/challenge/service/MemberChallengeDayService.java
@@ -1,0 +1,50 @@
+package com.nyam.everyday.module.challenge.service;
+
+import com.nyam.everyday.module.challenge.entity.Challenge;
+import com.nyam.everyday.module.challenge.entity.MemberChallengeDay;
+import com.nyam.everyday.module.challenge.repository.MemberChallengeDayRepository;
+import com.nyam.everyday.module.member.entity.Member;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberChallengeDayService {
+
+  private final MemberChallengeDayRepository memberChallengeDayRepository;
+
+  /**
+   * 멤버, 챌린지, 날짜에 적절한 MemberChallengeDay 데이터를 생성합니다, 이미 같은 값이 존재한다면, 수행하지 않습니다.
+   *
+   * @param member    회원
+   * @param challenge 대상 챌린지
+   * @param date      챌린지 진행 날짜
+   */
+  public void addMemberChallengeDay(Member member, Challenge challenge, LocalDate date) {
+    if (!memberChallengeDayRepository.existsByMember_MemberIdAndChallenge_IdAndTargetDate(
+        member.getMemberId(), challenge.getId(), date)) {
+      memberChallengeDayRepository.save(MemberChallengeDay.builder()
+          .member(member)
+          .challenge(challenge)
+          .targetDate(date)
+          .build()
+      );
+    }
+  }
+
+  /**
+   * 멤버, 챌린지, 날짜에 적절한 MemberChallengeDay 데이터를 삭제합니다(진행 취소 처리) 데이터가 존재하지 않는다면, 수행하지 않습니다.
+   *
+   * @param member    회원
+   * @param challenge 대상 챌린지
+   * @param date      챌린지 진행 날짜
+   */
+  public void deleteMemberChallengeDay(Member member, Challenge challenge, LocalDate date) {
+    if (memberChallengeDayRepository.existsByMember_MemberIdAndChallenge_IdAndTargetDate(
+        member.getMemberId(), challenge.getId(), date)) {
+      memberChallengeDayRepository.deleteMemberChallengeDay(member.getMemberId(), challenge.getId(),
+          date);
+    }
+  }
+}

--- a/everyday/src/main/java/com/nyam/everyday/module/challenge/service/MemberChallengeStatusService.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/challenge/service/MemberChallengeStatusService.java
@@ -1,4 +1,4 @@
-package com.nyam.everyday.module.challenge.checker.service;
+package com.nyam.everyday.module.challenge.service;
 
 import com.nyam.everyday.module.challenge.entity.Challenge;
 import com.nyam.everyday.module.challenge.entity.MemberChallengeStatus;
@@ -34,5 +34,15 @@ public class MemberChallengeStatusService {
     }
 
     return memberChallengeStatus;
+  }
+
+  // 어떤 유저가 특정 챌린지를 완료했는지 체크한다.
+  public boolean getIsCleared(Long memberId, Long challengeId) {
+    return memberChallengeStatusRepository.getIsCleared(memberId, challengeId).orElse(false);
+  }
+
+  // 어떤 유저의 챌린지 진행도를 체크한다
+  public Long getProgressCount(Long memberId, Long challengeId) {
+    return memberChallengeStatusRepository.getProgressCount(memberId, challengeId).orElse(0L);
   }
 }

--- a/everyday/src/main/java/com/nyam/everyday/module/chatting/chatmessage/service/ChatMessageService.java
+++ b/everyday/src/main/java/com/nyam/everyday/module/chatting/chatmessage/service/ChatMessageService.java
@@ -110,6 +110,8 @@ public class ChatMessageService {
     q.limit(20).with(Sort.by(Sort.Direction.DESC, "timestamp"));
     // ChatMessage 클래스를 지정해줌으로써 어떤 컬렉션에서 가져올 지 정해준다.
     List<ChatMessage> result_mongo = mongoTemplate.find(q, ChatMessage.class);
+    // TimeStamp의 DESC로 가져왔으니 역순이다. 뒤집어준다.
+    Collections.reverse(result_mongo);
 
     // 저장할 배열 생성
     List<ChatMessageBroadcastDto> result = new ArrayList<>();
@@ -125,8 +127,7 @@ public class ChatMessageService {
 
     log.info("Redis에 캐싱되어있지 않아 저장하고 결과 반환");
 
-    // 결과 반환
-    Collections.reverse(result);
+    // 결과 반환x
     return result;
   }
 

--- a/everyday/src/main/java/com/nyam/everyday/web/challenge/controller/ChallengeController.java
+++ b/everyday/src/main/java/com/nyam/everyday/web/challenge/controller/ChallengeController.java
@@ -1,0 +1,53 @@
+package com.nyam.everyday.web.challenge.controller;
+
+import com.nyam.everyday.module.challenge.service.ChallengeService;
+import com.nyam.everyday.security.core.CustomUserDetails;
+import com.nyam.everyday.web.challenge.dto.ChallengeDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/challenge")
+@RequiredArgsConstructor
+@Tag(name = "Challenge-Controller", description = "챌린지 관련 기능을 수행하는 컨트롤러입니다.")
+public class ChallengeController {
+
+  private final ChallengeService challengeService;
+
+  @GetMapping("/progressing")
+  @Operation(summary = "메인 페이지에 표시될 \"진행중인 챌린지\"의 목록을 2개까지 반환합니다.")
+  public ResponseEntity<List<ChallengeDto>> getProgressingChallenge(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    Long memberId = customUserDetails.getId();
+
+    List<ChallengeDto> result = challengeService.getProgressingChallenge(memberId);
+
+    return ResponseEntity.ok(result);
+  }
+
+  @GetMapping("/regular")
+  @Operation(summary = "챌린지 페이지의 \"상시 챌린지\"에 표시될 목록을 반환합니다.")
+  public ResponseEntity<List<ChallengeDto>> getRegularChallengeList(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    Long memberId = customUserDetails.getId();
+
+    List<ChallengeDto> result = challengeService.getRegularChallengeList(memberId);
+
+    return ResponseEntity.ok(result);
+  }
+
+  @GetMapping("/event")
+  @Operation(summary = "챌린지 페이지의 \"이벤트 챌린지\"에 표시될 목록을 반환합니다.")
+  public ResponseEntity<List<ChallengeDto>> getEventChallengeList(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    Long memberId = customUserDetails.getId();
+
+    List<ChallengeDto> result = challengeService.getEventChallengeList(memberId);
+
+    return ResponseEntity.ok(result);
+  }
+}

--- a/everyday/src/main/java/com/nyam/everyday/web/challenge/dto/ChallengeDto.java
+++ b/everyday/src/main/java/com/nyam/everyday/web/challenge/dto/ChallengeDto.java
@@ -1,0 +1,18 @@
+package com.nyam.everyday.web.challenge.dto;
+
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChallengeDto {
+
+  private String title;
+  private String description;
+  private boolean cleared;
+  private Long targetCount;
+  private Long progressCount;
+  private LocalDate startDate;
+  private LocalDate endDate;
+}


### PR DESCRIPTION
## 💭 작업 브랜치
> 브랜치를 적어주세요

feature/#128-ChallengeAPI

## 🍀 기능 설명
> 추가된 혹은 수정된 내용에 대해 간결하게 설명해주세요

프론트엔드에서 챌린지 관련 정보를 불러오기 위한 API들을 생성하였습니다
추가적으로 이전 Issue에서 완벽하지 않았던 횟수 기반 챌린지 체크 로직을 개선하였습니다.

## 관련된 Issue
> 어떤 이슈를 처리했는지 작성해주세요
<!-- 처리 완료된 이슈 번호를 "close #123" 형태로 작성해주시면 Issue가 자동으로 Close 됩니다 -->
close #128 
